### PR TITLE
ctaActions were not enabled for "primary" button styles

### DIFF
--- a/react/src/js/components/Consonant/Cards/OneHalf.jsx
+++ b/react/src/js/components/Consonant/Cards/OneHalf.jsx
@@ -242,7 +242,10 @@ const OneHalfCard = (props) => {
             } else if (cardButtonStyle === 'link') {
                 infobit.type = INFOBIT_TYPE.LINK;
             }
-            return infobit;
+            return {
+                ...infobit,
+                isCta: true,
+            };
         });
     }
 

--- a/react/src/js/components/Consonant/Cards/Text.jsx
+++ b/react/src/js/components/Consonant/Cards/Text.jsx
@@ -220,7 +220,10 @@ const TextCard = (props) => {
             } else if (cardButtonStyle === 'link') {
                 infobit.type = INFOBIT_TYPE.LINK;
             }
-            return infobit;
+            return {
+                ...infobit,
+                isCta: true,
+            };
         });
     }
 

--- a/react/src/js/components/Consonant/Infobit/Type/Button.jsx
+++ b/react/src/js/components/Consonant/Infobit/Type/Button.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import className from 'classnames';
-import { string, func } from 'prop-types';
+import { string, func, bool } from 'prop-types';
 
 import { useConfig } from '../../Helpers/hooks';
 import { getLinkTarget } from '../../Helpers/general';
@@ -18,6 +18,7 @@ const buttonType = {
     iconSrc: string,
     iconAlt: string,
     iconPos: string,
+    isCta: bool,
     onFocus: func,
 };
 
@@ -27,6 +28,7 @@ const defaultProps = {
     iconSrc: '',
     iconAlt: '',
     iconPos: '',
+    isCta: false,
     style: BUTTON_STYLE.CTA,
     onFocus: () => {},
 };
@@ -52,6 +54,7 @@ const Button = ({
     iconSrc,
     iconAlt,
     iconPos,
+    isCta,
     onFocus,
 }) => {
     /**
@@ -71,7 +74,7 @@ const Button = ({
     const isCtaButton = (style === BUTTON_STYLE.CTA && cardButtonStyle !== BUTTON_STYLE.PRIMARY) ||
         (cardButtonStyle === BUTTON_STYLE.CTA && style !== BUTTON_STYLE.SECONDARY);
 
-    if (isCtaButton) {
+    if (isCta) {
         ctaAction = getConfig('collection', 'ctaAction');
     }
 


### PR DESCRIPTION
fix(infobit/button): ctaAction was never applied if a cta had button style "primary" - this expressed itself on text and 1/2 cards.

Changed the mechanism with which we determine whether or not a button is a CTA. This allows buttons of multiple styles to access the ctaAction preferences when they are set.