### PR TITLE
refactor(.npmrc): removes unused file causing problems in Windows (MWPW-129283)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
-always-auth=false
-engine-strict=true


### PR DESCRIPTION
This unused _.npmrc_ file is causing _npm install_ to fail in Windows.

Resolves: https://jira.corp.adobe.com/browse/MWPW-129283
