### PR TITLE
build: includes build number to generated JS and CSS files (MWPW-135556)

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "babel-preset-env": "^1.7.0",
     "babel-preset-jest": "^22.4.4",
     "babel-preset-react": "^6.24.1",
-    "chromedriver": "114.0.0",
+    "chromedriver": "^116.0.0",
     "commitizen": "^4.2.6",
     "copy-webpack-plugin": "^4.6.0",
     "cross-env": "^5.2.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const StyleLintPlugin = require('stylelint-webpack-plugin');
 const webpack = require('webpack');
+const packageJson = require('./package.json');
 
 const extractStyles = new ExtractTextPlugin({
     filename: './app.css', // this is output name for file
@@ -22,7 +23,7 @@ const plugins = [
     extractStyles,
     listStyles,
     new webpack.BannerPlugin({
-        banner: `Chimera UI Libraries - Build ${date}
+        banner: `Chimera UI Libraries - Build ${packageJson.version} (${date})
         `,
         entryOnly: true,
     }),


### PR DESCRIPTION
Background:
Currently we have a webpack banner plugin that injects the build date to all the generated JS and CSS files.
The proposed solution updates the banner to include the build number.

Before
```
/*!
 * Chimera UI Libraries - Build -- 8/24/2023, 08:39:12
 *         
 */
```
After:
```
/*!
 * Chimera UI Libraries - Build 0.7.0 (8/24/2023, 08:39:12)
 *         
 */
```
 Resolves: https://jira.corp.adobe.com/browse/MWPW-135556
