### PR TITLE
fix(mwpw-167080): resolve GH Pages “No uploaded artifact found!” error for PR previews

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -119,7 +119,7 @@ jobs:
       - name: Upload Pages Artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          path: '.'
           name: github-pages
 
       # 8. Deploy the uploaded artifact to GitHub Pages (Preview Mode)

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -93,17 +93,49 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
+      # 1. Checkout the repository
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup Pages
-        uses: actions/configure-pages@v2
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+
+      # 2. Set up Node.js (version 16)
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
         with:
-          path: '.'
-      - name: Deploy to GitHub Pages
+          node-version: 16
+
+      # 3. Install dependencies using legacy peer deps to avoid conflicts
+      - name: Install dependencies
+        run: npm install --legacy-peer-deps
+
+      # 4. Run the build (Webpack should output to the dist/ folder)
+      - name: Build project
+        run: npm run build
+
+      # 6. Configure GitHub Pages
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v3
+
+      # 7. Upload the built site (dist/) as the artifact named "github-pages"
+      - name: Upload Pages Artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+          name: github-pages
+
+      # 8. Deploy the uploaded artifact to GitHub Pages (Preview Mode)
+      - name: Deploy to GitHub Pages (Preview)
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4
+        with:
+          artifact_name: github-pages
+          preview: true
+
+      # 9. Write the deployment URL to the job summary
+      - name: Write deployment URL to job summary
+        run: |
+          echo "## Pages Preview Deployment" >> $GITHUB_STEP_SUMMARY
+          echo "[View Deployment](${{ steps.deployment.outputs.page_url }})" >> $GITHUB_STEP_SUMMARY
+
   record-web-vitals:
     runs-on: ubuntu-latest
     needs: deployment

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -103,38 +103,32 @@ jobs:
         with:
           node-version: 16
 
-      # 3. Install dependencies using legacy peer deps to avoid conflicts
+      # 3. Install dependencies
       - name: Install dependencies
         run: npm install --legacy-peer-deps
 
-      # 4. Run the build (Webpack should output to the dist/ folder)
+      # 4. Run the build
       - name: Build project
         run: npm run build
 
-      # 6. Configure GitHub Pages
+      # 5. Configure GitHub Pages
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v3
 
-      # 7. Upload the built site (dist/) as the artifact named "github-pages"
+      # 6. Upload the built site as the artifact named "github-pages"
       - name: Upload Pages Artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: '.'
           name: github-pages
 
-      # 8. Deploy the uploaded artifact to GitHub Pages (Preview Mode)
+      # 7. Deploy the uploaded artifact to GitHub Pages
       - name: Deploy to GitHub Pages (Preview)
         id: deployment
         uses: actions/deploy-pages@v4
         with:
           artifact_name: github-pages
           preview: true
-
-      # 9. Write the deployment URL to the job summary
-      - name: Write deployment URL to job summary
-        run: |
-          echo "## Pages Preview Deployment" >> $GITHUB_STEP_SUMMARY
-          echo "[View Deployment](${{ steps.deployment.outputs.page_url }})" >> $GITHUB_STEP_SUMMARY
 
   record-web-vitals:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
This PR updates our pull-request workflow to fix the GitHub Pages “No uploaded artifact found!” error introduced after GitHub’s deprecation of the old artifact action (v3) on January 30, 2025. We now build and upload the entire repository `root (path: '.')` in the same job where we configure and deploy GitHub Pages using preview mode. This ensures that index.html and dist files are included, preventing 404 errors and fixing the previously failing PR previews.

### Change Summary:
- Added a Node.js setup and build step in the deployment job.
- Switched to `actions/configure-pages@v3` and `actions/deploy-pages@v4` with `preview: true`.
- Uploads the root folder `(path: '.')` as the artifact named `github-pages`.
- Removes references to the deprecated Pages actions `(v2)` which broke on January 30, 2025.

*Why*: GitHub Actions v3/v4 changed artifact permissions and requires ephemeral previews for pull requests.
*Result*: PR-based deployments now produce a working ephemeral preview site with no more “No uploaded artifact found!” errors.