### PR TITLE
test(mwpw-168628): adds smoke tests for main prod pages so we can check them before PR is merged

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -232,6 +232,15 @@ jobs:
           CHROME_VERSION=$(google-chrome --version | cut -d' ' -f3 | cut -d'.' -f1) 
           npm install chromedriver@$CHROME_VERSION
 
+      - name: Quick cURL Test (HTTP/1.1)
+        run: |
+          echo "Running a quick cURL test in HTTP/1.1 mode..."
+          curl -I --http1.1 https://www.adobe.com/acrobat/resources.html
+          curl -I --http1.1 https://www.adobe.com/acrobat/hub/change-page-size-of-pdf-in-4-steps.html
+          curl -I --http1.1 https://www.adobe.com/creativecloud/video/discover.html
+          curl -I --http1.1 https://www.adobe.com/in/acrobat/roc/blog/how-to-convert-zip-files-to-pdf-document.html
+          curl -I --http1.1 https://www.adobe.com/au/acrobat/resources.html
+
       - name: E2E
         run: npm run test:e2e-prod
 

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -227,7 +227,6 @@ jobs:
         run: | 
           CHROME_VERSION=$(google-chrome --version | cut -d' ' -f3 | cut -d'.' -f1) 
           npm install chromedriver@$CHROME_VERSION
-
       - name: E2E
         run: npm run test:e2e-prod
   run-accessibility-checks:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -214,21 +214,35 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Setup Chrome
         uses: browser-actions/setup-chrome@v1
         with:
           chrome-version: 'stable'
+
       - uses: actions/setup-node@v3
         with:
           node-version: 16.13.1
+
       - name: Install
         run: npm ci
+
       - name: Install Matching ChromeDriver
         run: | 
           CHROME_VERSION=$(google-chrome --version | cut -d' ' -f3 | cut -d'.' -f1) 
           npm install chromedriver@$CHROME_VERSION
+
       - name: E2E
         run: npm run test:e2e-prod
+
+      # Upload the screenshots as artifacts so you can download and inspect them
+      - name: Upload E2E Screenshots
+        if: always()   # ensures the upload runs even if tests fail
+        uses: actions/upload-artifact@v3
+        with:
+          name: e2e-screenshots
+          path: |
+            e2e-tests/screenshots
   run-accessibility-checks:
     runs-on: ubuntu-latest
     needs: deployment

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -214,44 +214,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
       - name: Setup Chrome
         uses: browser-actions/setup-chrome@v1
         with:
           chrome-version: 'stable'
-
       - uses: actions/setup-node@v3
         with:
           node-version: 16.13.1
-
       - name: Install
         run: npm ci
-
       - name: Install Matching ChromeDriver
         run: | 
           CHROME_VERSION=$(google-chrome --version | cut -d' ' -f3 | cut -d'.' -f1) 
           npm install chromedriver@$CHROME_VERSION
 
-      - name: Quick cURL Test (HTTP/1.1)
-        run: |
-          echo "Running a quick cURL test in HTTP/1.1 mode..."
-          curl -I --http1.1 https://www.adobe.com/acrobat/resources.html
-          curl -I --http1.1 https://www.adobe.com/acrobat/hub/change-page-size-of-pdf-in-4-steps.html
-          curl -I --http1.1 https://www.adobe.com/creativecloud/video/discover.html
-          curl -I --http1.1 https://www.adobe.com/in/acrobat/roc/blog/how-to-convert-zip-files-to-pdf-document.html
-          curl -I --http1.1 https://www.adobe.com/au/acrobat/resources.html
-
       - name: E2E
         run: npm run test:e2e-prod
-
-      # Upload the screenshots as artifacts so you can download and inspect them
-      - name: Upload E2E Screenshots
-        if: always()   # ensures the upload runs even if tests fail
-        uses: actions/upload-artifact@v4
-        with:
-          name: e2e-screenshots
-          path: |
-            e2e-tests/screenshots
   run-accessibility-checks:
     runs-on: ubuntu-latest
     needs: deployment

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -238,7 +238,7 @@ jobs:
       # Upload the screenshots as artifacts so you can download and inspect them
       - name: Upload E2E Screenshots
         if: always()   # ensures the upload runs even if tests fail
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-screenshots
           path: |

--- a/e2e-tests/specs/all.e2e.js
+++ b/e2e-tests/specs/all.e2e.js
@@ -296,7 +296,7 @@ describe('Analytics Tracking', () => {
 });
 
 describe('Dexter Events Page', () => {
-    let url = 'http://localhost:8000/html/dexter-events.html';
+    let url = 'http://localhost:5000/html/dexter-events.html';
     if (process.env.GITHUB_ACTIONS) {
         // eslint-disable-next-line no-template-curly-in-string
         url = 'https://adobecom.github.io/caas/html/dexter-events.html';
@@ -310,7 +310,7 @@ describe('Dexter Events Page', () => {
 });
 
 describe('Paginator out of Range', () => {
-    let url = 'http://localhost:8000/html/test-page.html?page=100';
+    let url = 'http://localhost:5000/html/test-page.html?page=100';
     if (process.env.GITHUB_ACTIONS) {
         // eslint-disable-next-line no-template-curly-in-string
         url = 'https://adobecom.github.io/caas/html/test-page.html';

--- a/e2e-tests/specs/all.e2e.js
+++ b/e2e-tests/specs/all.e2e.js
@@ -1,12 +1,6 @@
 // tests/e2e/collection.spec.js
 const generateUrl = require('../helpers/generateUrl');
 const config = require('../config.json');
-const fs = require('fs');
-const path = 'e2e-tests/screenshots';
-
-if (!fs.existsSync(path)) {
-    fs.mkdirSync(path, { recursive: true });
-}
 
 describe('Sort Options', () => {
     // Corrected line: Remove JSON.parse since config.sort.options is already an array
@@ -339,7 +333,6 @@ describe('Live Pages with ?caasbeta=true', () => {
         'https://www.adobe.com/acrobat/resources.html',
         'https://www.adobe.com/acrobat/hub/change-page-size-of-pdf-in-4-steps.html',
         'https://www.adobe.com/creativecloud/video/discover.html',
-        'https://www.adobe.com/in/acrobat/roc/blog/how-to-convert-zip-files-to-pdf-document.html',
         'https://www.adobe.com/au/acrobat/resources.html',
     ];
 

--- a/e2e-tests/specs/all.e2e.js
+++ b/e2e-tests/specs/all.e2e.js
@@ -296,7 +296,7 @@ describe('Analytics Tracking', () => {
 });
 
 describe('Dexter Events Page', () => {
-    let url = 'http://localhost:5000/html/dexter-events.html';
+    let url = 'http://localhost:8000/html/dexter-events.html';
     if (process.env.GITHUB_ACTIONS) {
         // eslint-disable-next-line no-template-curly-in-string
         url = 'https://adobecom.github.io/caas/html/dexter-events.html';
@@ -310,7 +310,7 @@ describe('Dexter Events Page', () => {
 });
 
 describe('Paginator out of Range', () => {
-    let url = 'http://localhost:5000/html/test-page.html?page=100';
+    let url = 'http://localhost:8000/html/test-page.html?page=100';
     if (process.env.GITHUB_ACTIONS) {
         // eslint-disable-next-line no-template-curly-in-string
         url = 'https://adobecom.github.io/caas/html/test-page.html';
@@ -324,27 +324,34 @@ describe('Paginator out of Range', () => {
 });
 
 describe('Live Pages with ?caasbeta=true', () => {
-    // Array of pages we want to test with ?caasbeta=true
+    // Use an array to test multiple pages with minimal logic
     const pages = [
-        'https://business.adobe.com/customer-success-stories.html',
-        'https://www.adobe.com/trust/resources.html',
-        'https://business.adobe.com/resources/main.html',
+        'https://www.adobe.com/acrobat/resources.html',
+        'https://www.adobe.com/acrobat/hub/change-page-size-of-pdf-in-4-steps.html',
+        'https://www.adobe.com/creativecloud/video/discover.html',
+        'https://www.adobe.com/in/acrobat/roc/blog/how-to-convert-zip-files-to-pdf-document.html',
+        'https://www.adobe.com/au/acrobat/resources.html',
     ];
 
     pages.forEach((page) => {
-        it(`should load the first card collection on: ${page}`, async () => {
-            // Append ?caasbeta=true to force the beta pipeline
-            const urlWithBeta = `${page}?caasbeta=true`;
-            await browser.url(urlWithBeta);
+        it(`should display the first card on: ${page}`, async () => {
+            // 1) Navigate with ?caasbeta=true
+            await browser.url(`${page}?caasbeta=true`);
 
-            // Wait for the first consonant card to appear
-            const firstCardSelector = '.consonant-Card';
-            await $(firstCardSelector).waitForExist({ timeout: 30000 });
-            await $(firstCardSelector).waitForDisplayed({ timeout: 30000 });
+            // 2) Scroll to ensure any lazy-loaded content is triggered.
+            //    Use a large scroll value to reach the bottom.
+            await browser.scroll(0, 9999);
+            // Short pause to allow content to load after scrolling
+            await browser.pause(2000);
 
-            // Check that the card is indeed displayed
-            const isDisplayed = await $(firstCardSelector).isDisplayed();
-            expect(isDisplayed).toBe(true);
+            // 3) Check for the first .consonant-Card
+            const cardSelector = '.consonant-Card';
+            await $(cardSelector).waitForExist({ timeout: 30000 });
+            await $(cardSelector).waitForDisplayed({ timeout: 30000 });
+
+            // 4) Confirm it’s displayed
+            const cardIsDisplayed = await $(cardSelector).isDisplayed();
+            expect(cardIsDisplayed).toBe(true);
         });
     });
 });

--- a/e2e-tests/specs/all.e2e.js
+++ b/e2e-tests/specs/all.e2e.js
@@ -322,3 +322,29 @@ describe('Paginator out of Range', () => {
         expect(await $(gridSelector).isDisplayed()).toBe(true);
     });
 });
+
+describe('Live Pages with ?caasbeta=true', () => {
+    // Array of pages we want to test with ?caasbeta=true
+    const pages = [
+        'https://business.adobe.com/customer-success-stories.html',
+        'https://www.adobe.com/trust/resources.html',
+        'https://business.adobe.com/resources/main.html',
+    ];
+
+    pages.forEach((page) => {
+        it(`should load the first card collection on: ${page}`, async () => {
+            // Append ?caasbeta=true to force the beta pipeline
+            const urlWithBeta = `${page}?caasbeta=true`;
+            await browser.url(urlWithBeta);
+
+            // Wait for the first consonant card to appear
+            const firstCardSelector = '.consonant-Card';
+            await $(firstCardSelector).waitForExist({ timeout: 30000 });
+            await $(firstCardSelector).waitForDisplayed({ timeout: 30000 });
+
+            // Check that the card is indeed displayed
+            const isDisplayed = await $(firstCardSelector).isDisplayed();
+            expect(isDisplayed).toBe(true);
+        });
+    });
+});

--- a/e2e-tests/specs/all.e2e.js
+++ b/e2e-tests/specs/all.e2e.js
@@ -324,11 +324,6 @@ describe('Paginator out of Range', () => {
 });
 
 describe('Live Pages with ?caasbeta=true', () => {
-    // Ensure the screenshot directory exists
-    if (!fs.existsSync(path)) {
-        fs.mkdirSync(path, { recursive: true });
-    }
-
     const pages = [
         'https://www.adobe.com/acrobat/resources.html',
         'https://www.adobe.com/acrobat/hub/change-page-size-of-pdf-in-4-steps.html',
@@ -349,30 +344,10 @@ describe('Live Pages with ?caasbeta=true', () => {
 
             // 3) Check for .consonant-Card
             const cardSelector = '.consonant-Card';
+            await $(cardSelector).waitForExist({ timeout: 30000 });
+            await $(cardSelector).waitForDisplayed({ timeout: 30000 });
 
-            try {
-                await $(cardSelector).waitForExist({ timeout: 30000 });
-                await $(cardSelector).waitForDisplayed({ timeout: 30000 });
-            } catch (err) {
-                // If the card doesn't appear, take a screenshot for debugging
-                const failurePath = `${path}/failure-${encodeURIComponent(page)}.png`;
-                console.log(`Test failed for ${page}, saving screenshot: ${failurePath}`);
-                await browser.saveScreenshot(failurePath);
-
-                // Optionally log <body> HTML to see what's really in the DOM
-                const bodyHTML = await $('body').getHTML();
-                console.log(`BODY HTML for ${page} on failure:\n${bodyHTML}\n\n`);
-
-                throw err; // re-throw so the test is marked as failed
-            }
-
-            // 4) If we reach here, the test passed
-            //    Still take a screenshot so we can see the final rendered state on success
-            const successPath = `${path}/success-${encodeURIComponent(page)}.png`;
-            console.log(`Test passed for ${page}, saving screenshot: ${successPath}`);
-            await browser.saveScreenshot(successPath);
-
-            // Final verification
+            // 4) Final verification
             const isDisplayed = await $(cardSelector).isDisplayed();
             expect(isDisplayed).toBe(true);
         });

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -21,7 +21,10 @@ exports.config = {
                 '--disable-dev-shm-usage', // Avoid /dev/shm issues in Docker
                 '--window-size=1440,735',
                 '--ignore-certificate-errors', // sometimes needed if SSL handshake fails
-                '--disable-web-security', // not typically recommended, but can help in some embed scenarios
+                '--disable-web-security', // not typically recommended, but can help in some embed scenarios,
+                '--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+                + 'AppleWebKit/537.36 (KHTML, like Gecko) '
+                + 'Chrome/98.0.4758.102 Safari/537.36',
             ],
         },
     }],

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -26,6 +26,7 @@ exports.config = {
                 + 'AppleWebKit/537.36 (KHTML, like Gecko) '
                 + 'Chrome/98.0.4758.102 Safari/537.36',
             ],
+            w3c: true,
         },
     }],
     logLevel: 'info',

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -17,10 +17,12 @@ exports.config = {
                 '--disable-infobars',
                 '--headless',
                 '--disable-gpu',
+                '--disable-http2', // Force HTTP/1.1
+                '--disable-dev-shm-usage', // Avoid /dev/shm issues in Docker
                 '--window-size=1440,735',
-                '--disable-http2',
+                '--ignore-certificate-errors', // sometimes needed if SSL handshake fails
+                '--disable-web-security', // not typically recommended, but can help in some embed scenarios
             ],
-            w3c: true,
         },
     }],
     logLevel: 'info',

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -18,6 +18,7 @@ exports.config = {
                 '--headless',
                 '--disable-gpu',
                 '--window-size=1440,735',
+                '--disable-http2',
             ],
             w3c: true,
         },


### PR DESCRIPTION
## Description
This PR updates our end-to-end tests so they can test multiple live pages (Customer Success Stories, Trust Resources, and Resources Main) by iterating over an array of URLs. Each URL is appended with `?caasbeta=true` to ensure we’re verifying the beta release.

Key points:
- Consolidates the previous approach (separate tests for each page) into a single test block.  
- Checks the first `.consonant-Card` within each page to confirm the card collection is loading.  
- Uses a `forEach` loop to test each URL in the list.

## Changes
1. **New test suite** (`describe('Live Pages with ?caasbeta=true', ...)`) to iterate over pages:
   - `https://business.adobe.com/customer-success-stories.html`
   - `https://www.adobe.com/trust/resources.html`
   - `https://business.adobe.com/resources/main.html`
2. **Waits for the first `.consonant-Card`** on the page to appear and verifies it’s displayed.  
3. **Ensures** that each URL is tested with `?caasbeta=true`.

## How to Test
1. **Pull** this branch locally.
2. **Run** the E2E tests (e.g., `npm run test` or `npm run e2e` — depending on your project’s commands).
3. Verify that the tests in the “Live Pages with ?caasbeta=true” suite pass.

## Additional Notes
- Timeout is set to **30 seconds** to accommodate slower load times.
- Selector `.consonant-Card` is intentionally broad, targeting the first card in the collection.
- Adjust the URL array if additional pages need testing.