### PR TITLE
fix(mwpw-182494): fixes accessibility issues

### DIFF
--- a/react/src/js/components/Consonant/Cards/Card.jsx
+++ b/react/src/js/components/Consonant/Cards/Card.jsx
@@ -464,8 +464,8 @@ const Card = (props) => {
                 data-testid="consonant-Card-header"
                 className="consonant-Card-header"
                 style={{ backgroundImage: `url("${image}")` }}
-                role={altText && 'img'}
-                aria-label={altText}>
+                role={(!isIcon && altText) ? 'img' : ''}
+                aria-label={!isIcon ? altText : ''}>
                 {hasBanner && !disableBanners && !isIcon && !isNews &&
                 <span
                     data-testid="consonant-Card-banner"


### PR DESCRIPTION
Fixes accessibility (aria) issues with icon-card layout
 
Resolves:
https://jira.corp.adobe.com/browse/MWPW-182494

Root cause:
If a card image image has altText value, the `aria-label` is populated and activates the screen reader.

Solution:
`aria-label` has been removed since the images are decorative