### PR TITLE
fix(mwpw-183221): fixes carousel navigation

### DIFF
--- a/react/src/js/components/Consonant/CardsCarousel/CardsCarousel.jsx
+++ b/react/src/js/components/Consonant/CardsCarousel/CardsCarousel.jsx
@@ -173,7 +173,7 @@ function CardsCarousel({
     }
 
     function shouldHideNextButton() {
-        const atEndOfCarousel = firstVisibleCard >= cards.length - cardsPerPage;
+        const atEndOfCarousel = firstVisibleCard > cards.length - cardsPerPage;
         if (atEndOfCarousel) {
             hideNextButton();
             if (userIsTabbing()) {


### PR DESCRIPTION
Fixes carousel navigation issue:
When there is only one card left to display the show next page button is hidden.

Resolves:
https://jira.corp.adobe.com/browse/MWPW-183221

Test page:
https://www.adobe.com/max/2025/sessions/max-sneaks-gs3.html?caasver=beta
