### PR TITLE
fix(mwpw-182728): adds fallback en strings

### DIFF
--- a/react/src/js/components/Consonant/CardsCarousel/CardsCarousel.jsx
+++ b/react/src/js/components/Consonant/CardsCarousel/CardsCarousel.jsx
@@ -78,8 +78,8 @@ function CardsCarousel({
     const title = getConfig('collection', 'i18n.title');
     const showTotalResults = getConfig('collection', 'showTotalResults');
     const showTotalResultsText = getConfig('collection', 'i18n.totalResultsText');
-    const nextCard = getConfig('collection', 'i18n.nextCards');
-    const prevCard = getConfig('collection', 'i18n.prevCards');
+    const nextCard = getConfig('collection', 'i18n.nextCards') || 'Next Cards';
+    const prevCard = getConfig('collection', 'i18n.prevCards') || 'Previous Cards';
     const useLightText = getConfig('collection', 'useLightText');
     const isIncremental = getConfig('pagination', 'animationStyle') === 'incremental';
     const renderOverlay = getConfig('collection', 'useOverlayLinks');


### PR DESCRIPTION
Description:
If the consumer mappings file does not contain prevCards and nextCards entries aria-labels are not being created.
This PR adds a fallback string. 

Resolves:
https://jira.corp.adobe.com/browse/MWPW-182728
