### PR TITLE
fix(mwpw-79208): fixes carousel width

### DIFF
--- a/less/components/consonant/cards-carousel.less
+++ b/less/components/consonant/cards-carousel.less
@@ -3,6 +3,8 @@
 .consonant-Wrapper--carousel {
     display: flex;
     justify-content: center;
+    width: calc(100% + 34px);
+    margin: 0 -17px;
 
     .consonant {
         &-Wrapper {


### PR DESCRIPTION
Description:
Increases the width of the carousel to take into account the navigation controllers
 
Resolves: https://jira.corp.adobe.com/browse/MWPW-179208

Before: 
<img width="1509" height="1036" alt="Screenshot 2025-11-13 at 2 07 18 PM" src="https://github.com/user-attachments/assets/1e4f088a-d436-4b77-bcd4-192994c128c1" />

After:
<img width="1424" height="1056" alt="Screenshot 2025-11-13 at 2 10 35 PM" src="https://github.com/user-attachments/assets/bfd4c8b4-a108-4a41-bf3e-adddeb6d2986" />
