### PR TITLE
fix(mwpw-177138): adds focus ring to filters

### DIFF
--- a/less/components/consonant/accessibility.less
+++ b/less/components/consonant/accessibility.less
@@ -9,6 +9,12 @@ body.tabbing {
             }
         }
 
+        button.consonant-LeftFilter-itemBadge:focus {
+            outline: @consonantFocusedColor solid 3px;
+            outline-offset: 3px;
+            border-radius: 50%;
+        }
+
         .consonant-Navigation--carousel {
             *:focus {
                 outline: @consonantFocusedColor solid 3px;


### PR DESCRIPTION
Adds a focus ring when tabbing through the page

Resolves: https://jira.corp.adobe.com/browse/MWPW-177138

<img width="329" height="381" alt="image" src="https://github.com/user-attachments/assets/2c2e580d-225c-4803-8d71-77239c8c0a2a" />
