### PR TITLE
fix(mwpw-183864): removes extra 83.3 percent css rules

### DIFF
--- a/less/components/consonant/wrapper.less
+++ b/less/components/consonant/wrapper.less
@@ -45,14 +45,12 @@
         /* Modifiers */
 
         &--1200MaxWidth &-inner {
-            width: 83.3%;
             max-width: @consonantDesktopMinWidth;
             margin-left: auto;
             margin-right: auto;
         }
 
         &--1600MaxWidth &-inner {
-            width: 83.3%;
             max-width: @consonantLargeDesktopMinWidth;
             margin-left: auto;
             margin-right: auto;


### PR DESCRIPTION
**Description**:
Removes 83.3% width CSS rule from 1200 and 1600 pixels containers
 
**Resolves**: 
https://jira.corp.adobe.com/browse/MWPW-183864

Test page (compare)
https://cmiqueo.github.io/compare/?url=https://business.adobe.com/resources/main.html&caasver=alpha

