### PR TITLE
fix: skip JIRA ticket check for Dependabot PRs

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,7 +8,8 @@ permissions: write-all
 jobs:
   check-pr-title:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    # Skip PR title check for Dependabot (doesn't use JIRA tickets)
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Dependabot PRs follow conventional commit format (build(deps): ...) but don't include JIRA tickets. This causes CI to fail on all Dependabot PRs.

This change skips the PR title linting check when the author is dependabot[bot], while keeping the requirement for human developers.