### PR TITLE
feat(mwpw-190445): run bulk publisher e2e tests against both prod and stage

### DIFF
--- a/e2e-tests/specs/bulk-publisher.e2e.js
+++ b/e2e-tests/specs/bulk-publisher.e2e.js
@@ -14,10 +14,21 @@
 
 const getAutomationToken = require('../helpers/getAutomationToken');
 
-const BULK_PUBLISHER_URL = 'https://milo.adobe.com/tools/send-to-caas/bulkpublisher.html';
 const DEV_POSTXDM_URL = 'https://14257-milocaasproxy-dev.adobeio-static.net/api/v1/web/milocaas/postXDM';
 const CLIENT_ID = 'b04b4dc3c96f4a2082f57237d84547a4';
-const TEST_PAGE_URL = 'https://milo.adobe.com/drafts/jmichnow/cards/document113';
+
+const ENVIRONMENTS = [
+  {
+    name: 'prod',
+    bulkPublisherUrl: 'https://milo.adobe.com/tools/send-to-caas/bulkpublisher.html',
+    testPageUrl: 'https://milo.adobe.com/drafts/jmichnow/cards/document113',
+  },
+  {
+    name: 'stage',
+    bulkPublisherUrl: 'https://stage--milo--adobecom.aem.live/tools/send-to-caas/bulkpublisher.html',
+    testPageUrl: 'https://stage--milo--adobecom.aem.live/drafts/jmichnow/cards/document113',
+  },
+];
 
 const SEL = {
   urlInput:      '#urls',
@@ -29,136 +40,138 @@ const SEL = {
   successRowOk:  'table.success-table td.ok',
 };
 
-describe('Bulk Publisher — Send to CaaS (dev)', () => {
-  let accessToken;
+ENVIRONMENTS.forEach(({ name, bulkPublisherUrl, testPageUrl }) => {
+  describe(`Bulk Publisher [${name}] — Send to CaaS (dev)`, () => {
+    let accessToken;
 
-  before(async () => {
-    accessToken = await getAutomationToken();
-  });
-
-  beforeEach(async () => {
-    await browser.url(BULK_PUBLISHER_URL);
-
-    // Wait for IMS library to be available
-    await browser.waitUntil(
-      () => browser.execute(() => typeof window.adobeImsFactory !== 'undefined'),
-      { timeout: 15000, timeoutMsg: 'adobeImsFactory did not load' },
-    );
-
-    // Create adobeIMS instance with our client_id + standalone token
-    await browser.execute((token, clientId) => {
-      const instance = window.adobeImsFactory.createIMSLib({
-        client_id: clientId,
-        scope: 'AdobeID,openid',
-        standalone: { token, expirems: 86399000 },
-        onAccessToken: () => {},
-        onReady: () => {},
-        onError: () => {},
-      }, 'adobeIMS');
-      window.adobeIMS = instance;
-      instance.initialize();
-    }, accessToken, CLIENT_ID);
-
-    // Wait for initialize to settle, then force token in via setStandAloneToken
-    await browser.pause(2000);
-    await browser.execute((token) => {
-      window.adobeIMS.setStandAloneToken({ token, expirems: 86399000 });
-    }, accessToken);
-
-    // Confirm getAccessToken() has our token
-    await browser.waitUntil(
-      () => browser.execute(() => !!window.adobeIMS.getAccessToken()),
-      { timeout: 10000, timeoutMsg: 'adobeIMS.getAccessToken() did not return a token' },
-    );
-
-    // Intercept window.fetch: redirect any postXDM call to the dev endpoint
-    // and ensure caas-env is set to dev with our service account token
-    await browser.execute((devUrl, token) => {
-      const origFetch = window.fetch;
-      window.fetch = (url, opts = {}) => {
-        if (typeof url === 'string' && url.includes('postXDM')) {
-          const headers = { ...(opts.headers || {}), 'caas-env': 'dev', 'Authorization': `Bearer ${token}` };
-          return origFetch(devUrl, { ...opts, headers });
-        }
-        return origFetch(url, opts);
-      };
-    }, DEV_POSTXDM_URL, accessToken);
-
-    // Select the "milo" preset (host=milo.adobe.com, repo=milo) to pass validation
-    await browser.execute(() => {
-      const preset = document.querySelector('#presetSelector');
-      preset.value = 'milo';
-      preset.dispatchEvent(new Event('change', { bubbles: true }));
-    });
-    await browser.pause(500);
-    await browser.execute(() => {
-      const env = document.querySelector('#caasEnv');
-      if (env) { env.value = 'dev'; env.dispatchEvent(new Event('change', { bubbles: true })); }
-    });
-  });
-
-  it('should successfully publish a page to CaaS dev', async () => {
-    const urlInput = await $(SEL.urlInput);
-    await urlInput.clearValue();
-    await urlInput.setValue(TEST_PAGE_URL);
-
-    await $(SEL.publishButton).click();
-
-    // Wait for progress modal to appear
-    await $(SEL.progressModal).waitForDisplayed({ timeout: 10000 });
-
-    // Wait for summary text in modal (appears after publish completes)
-    await browser.waitUntil(
-      () => browser.execute(() => {
-        const el = document.querySelector('.tingle-modal-box__content');
-        const text = el?.textContent || '';
-        return text.includes('Successfully published') || text.includes('Failed to publish');
-      }),
-      { timeout: 60000, timeoutMsg: 'Publish summary did not appear' },
-    );
-
-    const summaryText = await browser.execute(
-      () => document.querySelector('.tingle-modal-box__content')?.textContent || '',
-    );
-
-    // Dismiss summary modal
-    const tingleBtn = await $(SEL.tingleBtn);
-    if (await tingleBtn.isDisplayed()) await tingleBtn.click();
-
-    expect(summaryText).toMatch(/Successfully published [1-9]/);
-  });
-
-  it('should publish as draft when draftOnly is checked', async () => {
-    // Check draft-only via JS (avoids any visibility issues)
-    await browser.execute(() => {
-      const cb = document.querySelector('#draftOnly');
-      if (!cb.checked) cb.click();
+    before(async () => {
+      accessToken = await getAutomationToken();
     });
 
-    const urlInput = await $(SEL.urlInput);
-    await urlInput.clearValue();
-    await urlInput.setValue(TEST_PAGE_URL);
+    beforeEach(async () => {
+      await browser.url(bulkPublisherUrl);
 
-    await $(SEL.publishButton).click();
+      // Wait for IMS library to be available
+      await browser.waitUntil(
+        () => browser.execute(() => typeof window.adobeImsFactory !== 'undefined'),
+        { timeout: 15000, timeoutMsg: 'adobeImsFactory did not load' },
+      );
 
-    await $(SEL.progressModal).waitForDisplayed({ timeout: 10000 });
+      // Create adobeIMS instance with our client_id + standalone token
+      await browser.execute((token, clientId) => {
+        const instance = window.adobeImsFactory.createIMSLib({
+          client_id: clientId,
+          scope: 'AdobeID,openid',
+          standalone: { token, expirems: 86399000 },
+          onAccessToken: () => {},
+          onReady: () => {},
+          onError: () => {},
+        }, 'adobeIMS');
+        window.adobeIMS = instance;
+        instance.initialize();
+      }, accessToken, CLIENT_ID);
 
-    await browser.waitUntil(
-      () => browser.execute(() => {
-        const el = document.querySelector('.tingle-modal-box__content');
-        const text = el?.textContent || '';
-        return text.includes('Successfully published') || text.includes('Failed to publish');
-      }),
-      { timeout: 60000, timeoutMsg: 'Publish summary did not appear' },
-    );
+      // Wait for initialize to settle, then force token in via setStandAloneToken
+      await browser.pause(2000);
+      await browser.execute((token) => {
+        window.adobeIMS.setStandAloneToken({ token, expirems: 86399000 });
+      }, accessToken);
 
-    const summaryText = await browser.execute(
-      () => document.querySelector('.tingle-modal-box__content')?.textContent || '',
-    );
+      // Confirm getAccessToken() has our token
+      await browser.waitUntil(
+        () => browser.execute(() => !!window.adobeIMS.getAccessToken()),
+        { timeout: 10000, timeoutMsg: 'adobeIMS.getAccessToken() did not return a token' },
+      );
 
-    const tingleBtn = await $(SEL.tingleBtn);
-    if (await tingleBtn.isDisplayed()) await tingleBtn.click();
+      // Intercept window.fetch: redirect any postXDM call to the dev endpoint
+      // and ensure caas-env is set to dev with our service account token
+      await browser.execute((devUrl, token) => {
+        const origFetch = window.fetch;
+        window.fetch = (url, opts = {}) => {
+          if (typeof url === 'string' && url.includes('postXDM')) {
+            const headers = { ...(opts.headers || {}), 'caas-env': 'dev', 'Authorization': `Bearer ${token}` };
+            return origFetch(devUrl, { ...opts, headers });
+          }
+          return origFetch(url, opts);
+        };
+      }, DEV_POSTXDM_URL, accessToken);
 
-    expect(summaryText).toMatch(/Successfully published [1-9]/);
+      // Select the "milo" preset (host=milo.adobe.com, repo=milo) to pass validation
+      await browser.execute(() => {
+        const preset = document.querySelector('#presetSelector');
+        preset.value = 'milo';
+        preset.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+      await browser.pause(500);
+      await browser.execute(() => {
+        const env = document.querySelector('#caasEnv');
+        if (env) { env.value = 'dev'; env.dispatchEvent(new Event('change', { bubbles: true })); }
+      });
+    });
+
+    it('should successfully publish a page to CaaS dev', async () => {
+      const urlInput = await $(SEL.urlInput);
+      await urlInput.clearValue();
+      await urlInput.setValue(testPageUrl);
+
+      await $(SEL.publishButton).click();
+
+      // Wait for progress modal to appear
+      await $(SEL.progressModal).waitForDisplayed({ timeout: 10000 });
+
+      // Wait for summary text in modal (appears after publish completes)
+      await browser.waitUntil(
+        () => browser.execute(() => {
+          const el = document.querySelector('.tingle-modal-box__content');
+          const text = el?.textContent || '';
+          return text.includes('Successfully published') || text.includes('Failed to publish');
+        }),
+        { timeout: 60000, timeoutMsg: 'Publish summary did not appear' },
+      );
+
+      const summaryText = await browser.execute(
+        () => document.querySelector('.tingle-modal-box__content')?.textContent || '',
+      );
+
+      // Dismiss summary modal
+      const tingleBtn = await $(SEL.tingleBtn);
+      if (await tingleBtn.isDisplayed()) await tingleBtn.click();
+
+      expect(summaryText).toMatch(/Successfully published [1-9]/);
+    });
+
+    it('should publish as draft when draftOnly is checked', async () => {
+      // Check draft-only via JS (avoids any visibility issues)
+      await browser.execute(() => {
+        const cb = document.querySelector('#draftOnly');
+        if (!cb.checked) cb.click();
+      });
+
+      const urlInput = await $(SEL.urlInput);
+      await urlInput.clearValue();
+      await urlInput.setValue(testPageUrl);
+
+      await $(SEL.publishButton).click();
+
+      await $(SEL.progressModal).waitForDisplayed({ timeout: 10000 });
+
+      await browser.waitUntil(
+        () => browser.execute(() => {
+          const el = document.querySelector('.tingle-modal-box__content');
+          const text = el?.textContent || '';
+          return text.includes('Successfully published') || text.includes('Failed to publish');
+        }),
+        { timeout: 60000, timeoutMsg: 'Publish summary did not appear' },
+      );
+
+      const summaryText = await browser.execute(
+        () => document.querySelector('.tingle-modal-box__content')?.textContent || '',
+      );
+
+      const tingleBtn = await $(SEL.tingleBtn);
+      if (await tingleBtn.isDisplayed()) await tingleBtn.click();
+
+      expect(summaryText).toMatch(/Successfully published [1-9]/);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Run the same bulk publisher e2e test suite against both prod (`milo.adobe.com`) and stage (`stage--milo--adobecom.aem.live`)
- Prod tests catch live issues affecting real authors
- Stage tests catch milo dev regressions before they reach prod
- Both environments publish to CaaS dev via the existing fetch intercept — nothing goes live

## Test plan
- [x] Verified `stage--milo--adobecom.aem.live` loads bulk publisher with `adobeImsFactory` available
- [x] All 4 tests pass locally (2 prod + 2 stage) in a single run (17.5s)