### PR TITLE
fix(mwpw-190906): updates focus color on dark background

### DIFF
--- a/less/components/consonant/accessibility.less
+++ b/less/components/consonant/accessibility.less
@@ -6,6 +6,16 @@ body.tabbing {
         .consonant-Pagination {
             *:focus {
                 border: @consonantFocusedColor solid 2px;
+
+                &:after {
+                    border-color: transparent;
+                }
+            }
+        }
+
+        .consonant-Pagination.lightText {
+            *:focus {
+                border: #dedede solid 2px !important;
             }
         }
 


### PR DESCRIPTION
Description:
Sets the focus color to white on dark background when using LightText

Resolves:
https://jira.corp.adobe.com/browse/MWPW-190906

Before:
https://www.adobe.com/events.html
<img width="585" height="62" alt="Screenshot 2026-04-08 at 1 57 42 PM" src="https://github.com/user-attachments/assets/993a73bf-3a17-418e-bc82-e6fabc1a1bf5" />

After:
https://www.adobe.com/events.html?caasver=beta
<img width="578" height="72" alt="Screenshot 2026-04-08 at 1 57 18 PM" src="https://github.com/user-attachments/assets/f1a4241e-880a-4bf5-81fd-a3ea69e64830" />
