### PR TITLE
test(mwpw-192380): left Filter Panel Automation

### DIFF
--- a/caas/mock-json/test-group-filters.json
+++ b/caas/mock-json/test-group-filters.json
@@ -1,0 +1,356 @@
+{
+  "cards": [
+    {
+      "id": "card-photoshop-only",
+      "showCard": {
+        "from": "2020-10-01T20:00:00Z",
+        "until": "2099-12-31T21:45:00Z"
+      },
+      "tags": [
+        {
+          "id": "caas:products/photoshop"
+        }
+      ],
+      "overlays": {
+        "banner": {
+          "backgroundColor": "#31A8FF",
+          "fontColor": "#FFFFFF",
+          "description": "Photoshop Only",
+          "icon": ""
+        },
+        "logo": {},
+        "label": {},
+        "videoButton": {}
+      },
+      "contentArea": {
+        "detailText": "TEST CARD",
+        "title": "Card #1: Tagged with PHOTOSHOP only",
+        "description": "This card should appear when: (1) Photoshop filter is selected, (2) Creative Cloud group is selected",
+        "dateDetailText": {}
+      },
+      "styles": {
+        "typeOverride": "1:2",
+        "backgroundImage": "https://caas-chimera.s3-us-west-1.amazonaws.com/img/cat.png"
+      },
+      "footer": [
+        {
+          "divider": true,
+          "left": [],
+          "center": [],
+          "right": [
+            {
+              "type": "button",
+              "style": "call-to-action",
+              "text": "Read More",
+              "href": "https://www.google.com"
+            }
+          ]
+        }
+      ],
+      "cardDate": "2024-01-01T09:00:00.000Z"
+    },
+    {
+      "id": "card-creative-cloud-tag",
+      "showCard": {
+        "from": "2020-10-01T20:00:00Z",
+        "until": "2099-12-31T21:45:00Z"
+      },
+      "tags": [
+        {
+          "id": "caas:products/creative-cloud"
+        }
+      ],
+      "overlays": {
+        "banner": {
+          "backgroundColor": "#FF0000",
+          "fontColor": "#FFFFFF",
+          "description": "Creative Cloud Tag",
+          "icon": ""
+        },
+        "logo": {},
+        "label": {},
+        "videoButton": {}
+      },
+      "contentArea": {
+        "detailText": "TEST CARD",
+        "title": "Card #2: Tagged with CREATIVE-CLOUD tag (NOT a product)",
+        "description": "This card should NOT appear when Creative Cloud group is selected, because it's tagged with the group ID itself, not any of its child products",
+        "dateDetailText": {}
+      },
+      "styles": {
+        "typeOverride": "1:2",
+        "backgroundImage": "https://caas-chimera.s3-us-west-1.amazonaws.com/img/cat.png"
+      },
+      "footer": [
+        {
+          "divider": true,
+          "left": [],
+          "center": [],
+          "right": [
+            {
+              "type": "button",
+              "style": "call-to-action",
+              "text": "Read More",
+              "href": "https://www.google.com"
+            }
+          ]
+        }
+      ],
+      "cardDate": "2024-01-02T09:00:00.000Z"
+    },
+    {
+      "id": "card-photoshop-illustrator",
+      "showCard": {
+        "from": "2020-10-01T20:00:00Z",
+        "until": "2099-12-31T21:45:00Z"
+      },
+      "tags": [
+        {
+          "id": "caas:products/photoshop"
+        },
+        {
+          "id": "caas:products/illustrator"
+        }
+      ],
+      "overlays": {
+        "banner": {
+          "backgroundColor": "#FF9A00",
+          "fontColor": "#FFFFFF",
+          "description": "Multiple Products",
+          "icon": ""
+        },
+        "logo": {},
+        "label": {},
+        "videoButton": {}
+      },
+      "contentArea": {
+        "detailText": "TEST CARD",
+        "title": "Card #3: Tagged with PHOTOSHOP and ILLUSTRATOR",
+        "description": "This card should appear when: (1) Photoshop filter is selected, (2) Illustrator filter is selected, (3) Creative Cloud group is selected",
+        "dateDetailText": {}
+      },
+      "styles": {
+        "typeOverride": "1:2",
+        "backgroundImage": "https://caas-chimera.s3-us-west-1.amazonaws.com/img/cat.png"
+      },
+      "footer": [
+        {
+          "divider": true,
+          "left": [],
+          "center": [],
+          "right": [
+            {
+              "type": "button",
+              "style": "call-to-action",
+              "text": "Read More",
+              "href": "https://www.google.com"
+            }
+          ]
+        }
+      ],
+      "cardDate": "2024-01-03T09:00:00.000Z"
+    },
+    {
+      "id": "card-acrobat-only",
+      "showCard": {
+        "from": "2020-10-01T20:00:00Z",
+        "until": "2099-12-31T21:45:00Z"
+      },
+      "tags": [
+        {
+          "id": "caas:products/acrobat"
+        }
+      ],
+      "overlays": {
+        "banner": {
+          "backgroundColor": "#DC3545",
+          "fontColor": "#FFFFFF",
+          "description": "Acrobat Only",
+          "icon": ""
+        },
+        "logo": {},
+        "label": {},
+        "videoButton": {}
+      },
+      "contentArea": {
+        "detailText": "TEST CARD",
+        "title": "Card #4: Tagged with ACROBAT only (Document Cloud)",
+        "description": "This card should appear when: (1) Acrobat filter is selected, (2) Document Cloud group is selected. Should NOT appear when Creative Cloud group is selected.",
+        "dateDetailText": {}
+      },
+      "styles": {
+        "typeOverride": "1:2",
+        "backgroundImage": "https://caas-chimera.s3-us-west-1.amazonaws.com/img/cat.png"
+      },
+      "footer": [
+        {
+          "divider": true,
+          "left": [],
+          "center": [],
+          "right": [
+            {
+              "type": "button",
+              "style": "call-to-action",
+              "text": "Read More",
+              "href": "https://www.google.com"
+            }
+          ]
+        }
+      ],
+      "cardDate": "2024-01-04T09:00:00.000Z"
+    },
+    {
+      "id": "card-indesign-premiere",
+      "showCard": {
+        "from": "2020-10-01T20:00:00Z",
+        "until": "2099-12-31T21:45:00Z"
+      },
+      "tags": [
+        {
+          "id": "caas:products/indesign"
+        },
+        {
+          "id": "caas:products/premiere-pro"
+        }
+      ],
+      "overlays": {
+        "banner": {
+          "backgroundColor": "#9900FF",
+          "fontColor": "#FFFFFF",
+          "description": "Multiple CC Products",
+          "icon": ""
+        },
+        "logo": {},
+        "label": {},
+        "videoButton": {}
+      },
+      "contentArea": {
+        "detailText": "TEST CARD",
+        "title": "Card #5: Tagged with INDESIGN and PREMIERE PRO",
+        "description": "This card should appear when: (1) InDesign filter is selected, (2) Premiere Pro filter is selected, (3) Creative Cloud group is selected",
+        "dateDetailText": {}
+      },
+      "styles": {
+        "typeOverride": "1:2",
+        "backgroundImage": "https://caas-chimera.s3-us-west-1.amazonaws.com/img/cat.png"
+      },
+      "footer": [
+        {
+          "divider": true,
+          "left": [],
+          "center": [],
+          "right": [
+            {
+              "type": "button",
+              "style": "call-to-action",
+              "text": "Read More",
+              "href": "https://www.google.com"
+            }
+          ]
+        }
+      ],
+      "cardDate": "2024-01-05T09:00:00.000Z"
+    },
+    {
+      "id": "card-analytics-target",
+      "showCard": {
+        "from": "2020-10-01T20:00:00Z",
+        "until": "2099-12-31T21:45:00Z"
+      },
+      "tags": [
+        {
+          "id": "caas:products/analytics"
+        },
+        {
+          "id": "caas:products/target"
+        }
+      ],
+      "overlays": {
+        "banner": {
+          "backgroundColor": "#28A745",
+          "fontColor": "#FFFFFF",
+          "description": "Experience Cloud",
+          "icon": ""
+        },
+        "logo": {},
+        "label": {},
+        "videoButton": {}
+      },
+      "contentArea": {
+        "detailText": "TEST CARD",
+        "title": "Card #6: Tagged with ANALYTICS and TARGET (Experience Cloud)",
+        "description": "This card should appear when: (1) Analytics filter is selected, (2) Target filter is selected, (3) Experience Cloud group is selected",
+        "dateDetailText": {}
+      },
+      "styles": {
+        "typeOverride": "1:2",
+        "backgroundImage": "https://caas-chimera.s3-us-west-1.amazonaws.com/img/cat.png"
+      },
+      "footer": [
+        {
+          "divider": true,
+          "left": [],
+          "center": [],
+          "right": [
+            {
+              "type": "button",
+              "style": "call-to-action",
+              "text": "Read More",
+              "href": "https://www.google.com"
+            }
+          ]
+        }
+      ],
+      "cardDate": "2024-01-06T09:00:00.000Z"
+    },
+    {
+      "id": "card-no-products",
+      "showCard": {
+        "from": "2020-10-01T20:00:00Z",
+        "until": "2099-12-31T21:45:00Z"
+      },
+      "tags": [
+        {
+          "id": "adobe-com-enterprise:topic/digital-trends"
+        }
+      ],
+      "overlays": {
+        "banner": {
+          "backgroundColor": "#6C757D",
+          "fontColor": "#FFFFFF",
+          "description": "No Products",
+          "icon": ""
+        },
+        "logo": {},
+        "label": {},
+        "videoButton": {}
+      },
+      "contentArea": {
+        "detailText": "TEST CARD",
+        "title": "Card #7: NO product tags (only topic tags)",
+        "description": "This card should appear when NO product filters are selected. Should disappear when any product or group filter is selected.",
+        "dateDetailText": {}
+      },
+      "styles": {
+        "typeOverride": "1:2",
+        "backgroundImage": "https://caas-chimera.s3-us-west-1.amazonaws.com/img/cat.png"
+      },
+      "footer": [
+        {
+          "divider": true,
+          "left": [],
+          "center": [],
+          "right": [
+            {
+              "type": "button",
+              "style": "call-to-action",
+              "text": "Read More",
+              "href": "https://www.google.com"
+            }
+          ]
+        }
+      ],
+      "cardDate": "2024-01-07T09:00:00.000Z"
+    }
+  ]
+}

--- a/e2e-tests/specs/filters.e2e.js
+++ b/e2e-tests/specs/filters.e2e.js
@@ -1,0 +1,185 @@
+// Left filter panel: selecting, deselecting, and clearing filters
+const generateUrl = require('../helpers/generateUrl');
+
+/**
+ * test-group-filters.json has 7 cards with these tags:
+ *   #1 card-photoshop-only:       caas:products/photoshop
+ *   #2 card-creative-cloud-tag:   caas:products/creative-cloud
+ *   #3 card-photoshop-illustrator: caas:products/photoshop, caas:products/illustrator
+ *   #4 card-acrobat-only:         caas:products/acrobat
+ *   #5 card-indesign-premiere:    caas:products/indesign, caas:products/premiere-pro
+ *   #6 card-analytics-target:     caas:products/analytics, caas:products/target
+ *   #7 card-no-products:          adobe-com-enterprise:topic/digital-trends (no product tags)
+ */
+const TOTAL_CARDS = 7;
+
+const filterOverrides = {
+    collection: {
+        endpoint: '../../mock-json/test-group-filters.json',
+        totalCardsToShow: '-1',
+        resultsPerPage: '20',
+    },
+    filterPanel: {
+        enabled: 'true',
+        type: 'left',
+        filterLogic: 'or',
+        showEmptyFilters: true,
+        filters: [
+            {
+                group: 'Products',
+                id: 'caas:products',
+                openedOnLoad: true,
+                items: [
+                    { label: 'Photoshop', id: 'caas:products/photoshop' },
+                    { label: 'Illustrator', id: 'caas:products/illustrator' },
+                    { label: 'Acrobat', id: 'caas:products/acrobat' },
+                ],
+            },
+        ],
+    },
+    sort: {
+        enabled: 'false',
+    },
+    search: {
+        enabled: 'false',
+    },
+    pagination: {
+        enabled: 'false',
+    },
+};
+
+const SEL = {
+    card: '.consonant-Card',
+    filterPanel: '.consonant-LeftFilters',
+    filterGroup: '.consonant-LeftFilter',
+    filterGroupLink: '.consonant-LeftFilter-link',
+    filterItems: '.consonant-LeftFilter-items',
+    clearAllBtn: '.consonant-LeftFilters-clearLink',
+    groupBadge: '.consonant-LeftFilter-itemBadge',
+};
+
+const checkboxLabel = (itemId) => `label[for="${itemId}"]`;
+
+const waitForCardCount = async (expectedCount) => {
+    await browser.waitUntil(async () => {
+        const cards = await $$('.consonant-Card');
+        return cards.length === expectedCount;
+    }, {
+        timeout: 10000,
+        timeoutMsg: `Expected ${expectedCount} cards but found a different count`,
+    });
+};
+
+describe('Left Filter Panel', () => {
+    const url = generateUrl(filterOverrides);
+
+    beforeEach(async () => {
+        await browser.url(url);
+        await $(SEL.card).waitForExist({ timeout: 10000 });
+    });
+
+    it('should render the left filter panel when enabled', async () => {
+        const panel = await $(SEL.filterPanel);
+        expect(await panel.isDisplayed()).toBe(true);
+    });
+
+    it('should display all cards when no filters are selected', async () => {
+        const cards = await $$(SEL.card);
+        expect(cards.length).toBe(TOTAL_CARDS);
+    });
+
+    it('should narrow cards when selecting a single filter item', async () => {
+        const label = await $(checkboxLabel('caas:products/photoshop'));
+        await label.waitForDisplayed({ timeout: 10000 });
+        await label.click();
+
+        // Photoshop matches cards #1 and #3
+        await waitForCardCount(2);
+        const cards = await $$(SEL.card);
+        expect(cards.length).toBe(2);
+    });
+
+    it('should widen results when selecting an additional item (OR logic)', async () => {
+        const psLabel = await $(checkboxLabel('caas:products/photoshop'));
+        await psLabel.waitForDisplayed({ timeout: 10000 });
+        await psLabel.click();
+        await waitForCardCount(2);
+
+        // Add Acrobat: OR union includes cards #1, #3, #4
+        const acLabel = await $(checkboxLabel('caas:products/acrobat'));
+        await acLabel.click();
+        await waitForCardCount(3);
+
+        const cards = await $$(SEL.card);
+        expect(cards.length).toBe(3);
+    });
+
+    it('should update results when deselecting a filter item', async () => {
+        // Select both Photoshop and Acrobat
+        const psLabel = await $(checkboxLabel('caas:products/photoshop'));
+        await psLabel.waitForDisplayed({ timeout: 10000 });
+        await psLabel.click();
+        await waitForCardCount(2);
+
+        const acLabel = await $(checkboxLabel('caas:products/acrobat'));
+        await acLabel.click();
+        await waitForCardCount(3);
+
+        // Deselect Photoshop: only Acrobat remains, matching card #4
+        await psLabel.click();
+        await waitForCardCount(1);
+
+        const cards = await $$(SEL.card);
+        expect(cards.length).toBe(1);
+    });
+
+    it('should restore all cards when clearing all filters', async () => {
+        const psLabel = await $(checkboxLabel('caas:products/photoshop'));
+        await psLabel.waitForDisplayed({ timeout: 10000 });
+        await psLabel.click();
+        await waitForCardCount(2);
+
+        const clearBtn = await $(SEL.clearAllBtn);
+        await clearBtn.click();
+        await waitForCardCount(TOTAL_CARDS);
+
+        const cards = await $$(SEL.card);
+        expect(cards.length).toBe(TOTAL_CARDS);
+    });
+
+    it('should clear a single filter group via the group badge', async () => {
+        const psLabel = await $(checkboxLabel('caas:products/photoshop'));
+        await psLabel.waitForDisplayed({ timeout: 10000 });
+        await psLabel.click();
+        await waitForCardCount(2);
+
+        // Group badge appears showing "1" selected; clicking it clears the group
+        const badge = await $(SEL.groupBadge);
+        await badge.waitForDisplayed({ timeout: 5000 });
+        await badge.click();
+        await waitForCardCount(TOTAL_CARDS);
+
+        const cards = await $$(SEL.card);
+        expect(cards.length).toBe(TOTAL_CARDS);
+    });
+
+    it('should expand a collapsed filter group on click', async () => {
+        const closedOverrides = JSON.parse(JSON.stringify(filterOverrides));
+        closedOverrides.filterPanel.filters[0].openedOnLoad = false;
+        const closedUrl = generateUrl(closedOverrides);
+        await browser.url(closedUrl);
+
+        await $(SEL.filterGroup).waitForExist({ timeout: 10000 });
+
+        // Items hidden when group is collapsed
+        const items = await $(SEL.filterItems);
+        expect(await items.isDisplayed()).toBe(false);
+
+        // Click group heading to expand
+        const groupLink = await $(SEL.filterGroupLink);
+        await groupLink.click();
+
+        await items.waitForDisplayed({ timeout: 5000 });
+        expect(await items.isDisplayed()).toBe(true);
+    });
+});

--- a/e2e-tests/specs/filters.e2e.js
+++ b/e2e-tests/specs/filters.e2e.js
@@ -15,7 +15,7 @@ const TOTAL_CARDS = 7;
 
 const filterOverrides = {
     collection: {
-        endpoint: '../../mock-json/test-group-filters.json',
+        endpoint: '../../caas/mock-json/test-group-filters.json',
         totalCardsToShow: '-1',
         resultsPerPage: '20',
     },

--- a/e2e-tests/specs/filters.e2e.js
+++ b/e2e-tests/specs/filters.e2e.js
@@ -1,3 +1,4 @@
+// AI Review Test - triggering workflow
 // Left filter panel: selecting, deselecting, and clearing filters
 const generateUrl = require('../helpers/generateUrl');
 

--- a/e2e-tests/specs/filters.e2e.js
+++ b/e2e-tests/specs/filters.e2e.js
@@ -1,4 +1,4 @@
-// AI Review Test v2 - fixed workflow
+// AI Review Test v3
 // Left filter panel: selecting, deselecting, and clearing filters
 const generateUrl = require('../helpers/generateUrl');
 

--- a/e2e-tests/specs/filters.e2e.js
+++ b/e2e-tests/specs/filters.e2e.js
@@ -1,4 +1,4 @@
-// AI Review Test - triggering workflow
+// AI Review Test v2 - fixed workflow
 // Left filter panel: selecting, deselecting, and clearing filters
 const generateUrl = require('../helpers/generateUrl');
 


### PR DESCRIPTION
Left Filter Panel Automation: Enable left filters, click filter items, verify card set narrows

- render the left filter panel when enabled
- display all cards when no filters are selected
- narrow cards when selecting a single filter item
- widen results when selecting an additional item (OR logic)
-  update results when deselecting a filter item
- restore all cards when clearing all filters
- clear a single filter group via the group badge
- expand a collapsed filter group on click

Resolves: [MWPW-192380](https://jira.corp.adobe.com/browse/MWPW-192380)