### PR TITLE
fix(mwpw-177207): adds visible Sort by: label to sort dropdown

### DIFF
--- a/less/components/consonant/filters/top/panel.less
+++ b/less/components/consonant/filters/top/panel.less
@@ -13,7 +13,7 @@
         &-inner {
             display: flex;
             flex-wrap: wrap;
-            justify-content: space-between;
+            justify-content: flex-end;
             align-items: flex-start;
             max-width: 100%;
         }
@@ -37,7 +37,7 @@
             justify-content: flex-end;
             align-items: flex-start;
             flex-grow: 1;
-            max-width: calc(~ '100% - ' @consonant-Select-width * 0.85 ~ ' - 8px');
+            max-width: calc(~ '100% - ' @consonant-Select-width ~ ' - 8px');
 
             &:first-child {
                 max-width: 100%;
@@ -157,7 +157,6 @@
         &-selectWrapper {
             display: flex;
             justify-content: flex-end;
-            width: @consonant-Select-width * 0.85;
             margin-right: 8px;
             order: -1;
             overflow: visible;
@@ -273,7 +272,6 @@
             }
 
             &-selectWrapper {
-                max-width: @consonant-Select-width;
                 order: 0;
                 margin-right: 0;
             }
@@ -316,13 +314,12 @@
 
             &-selectWrapper {
                 min-width: auto;
-                max-width: 160px;
                 margin-right: 0;
                 margin-left: 0;
 
                 & > div:first-child > button {
-                    padding-left: 12px;
-                    padding-right: 12px;
+                    // padding-left: 12px;
+                    padding-right: 24px;
                     border: 1px solid @consonantLightGrey200;
                     border-radius: 4px;
                 }
@@ -331,7 +328,7 @@
 
                 & > div:first-child {
                     &:after {
-                        right: 12px;
+                        right: 4px;
                     }
                 }
             }

--- a/less/components/consonant/filters/top/panel.less
+++ b/less/components/consonant/filters/top/panel.less
@@ -318,7 +318,6 @@
                 margin-left: 0;
 
                 & > div:first-child > button {
-                    // padding-left: 12px;
                     padding-right: 24px;
                     border: 1px solid @consonantLightGrey200;
                     border-radius: 4px;

--- a/less/components/consonant/select.less
+++ b/less/components/consonant/select.less
@@ -134,8 +134,8 @@
             margin-bottom: 0;
 
             &:after {
-                width: 4px;
-                height: 4px;
+                width: 6px;
+                height: 6px;
                 border-color: @consonantDarkGrey400;
             }
         }
@@ -146,6 +146,31 @@
 
         &--autoWidth &-btn {
             max-width: 100%;
+        }
+
+        &.sort-by-Select {
+            display: flex;
+            width: auto;
+            justify-content: flex-end;
+            align-items: baseline;
+
+            label {
+                font-size: 13px;
+                width: auto;
+                padding-top: 2px;
+                text-align: right;
+                white-space: nowrap;
+            }
+
+            .consonant-Select-btn {
+                max-width: none;
+                padding-left: 6px;
+                padding-right: 20px;
+            }
+
+            &:after {
+                right: 4px;
+            }
         }
 
         @media @consonant-tablet-up {

--- a/react/src/js/components/Consonant/Helpers/constants.js
+++ b/react/src/js/components/Consonant/Helpers/constants.js
@@ -156,6 +156,7 @@ export const DEFAULT_CONFIG = {
             title: '',
             onErrorTitle: 'Sorry there was a system error.',
             onErrorDescription: 'Please try reloading the page or try coming back to the page another time.',
+            sortBy: 'Sort by:',
             sortByAria: 'Sort by {key}',
             removeFilterAria: 'Remove {filter} filter',
             removeAllFiltersAria: 'Remove {num} {filter} filters',

--- a/react/src/js/components/Consonant/Sort/Popup.jsx
+++ b/react/src/js/components/Consonant/Sort/Popup.jsx
@@ -57,6 +57,7 @@ const Popup = ({
      **** Authored Configs ****
      */
     const getConfig = useConfig();
+    const sortBy = getConfig('collection', 'i18n.sortBy');
     const sortByAria = getConfig('collection', 'i18n.sortByAria');
 
     /**
@@ -99,9 +100,11 @@ const Popup = ({
 
     return (
         <div
-            className={shouldAutoWidthSortClass}>
+            className={`${shouldAutoWidthSortClass} sort-by-Select`}>
+            <label htmlFor="consonant-Select-btn" data-testid="consonant-Select-label">{sortBy}</label>
             <button
                 data-testid="consonant-Select-btn"
+                id="consonant-Select-btn"
                 type="button"
                 onClick={handleToggle}
                 className={openButtonClass}

--- a/react/src/js/components/Consonant/Sort/__tests__/Popup.spec.js
+++ b/react/src/js/components/Consonant/Sort/__tests__/Popup.spec.js
@@ -9,6 +9,14 @@ import { testAccessibility } from '../../Testing/Utils/a11yTest';
 const renderSortPopup = setup(Popup, DEFAULT_PROPS);
 
 describe('Consonant/Sort/Popup', () => {
+    test('Should show sort by label', async () => {
+        renderSortPopup();
+        const sortPopLabel = screen.getByTestId('consonant-Select-label');
+
+        expect(sortPopLabel).toHaveTextContent('Sort by:');
+        expect(sortPopLabel).not.toHaveAttribute('aria-label');
+    });
+
     test('Should show all sort options', async () => {
         const { props: { values } } = renderSortPopup();
         const sortPopup = screen.getByTestId('consonant-Select-btn');


### PR DESCRIPTION
**Description**:
Adds a visible text label before the sort dropdown button in the Consonant top-filter panel, replacing the implicit-only aria-label with an explicit paired <label> element.

**L10n:**
It can be localized by using the following new key in the mappings file 
`sortBy: "Sort by:"`

**Resolves**:
https://jira.corp.adobe.com/browse/MWPW-177207

**Before**:
<img width="308" height="52" alt="Screenshot 2026-04-30 at 8 41 40 AM" src="https://github.com/user-attachments/assets/e9afe59d-c9f7-4bd3-8901-6ef4e2141396" />

**After**:
<img width="358" height="50" alt="Screenshot 2026-04-30 at 8 41 12 AM" src="https://github.com/user-attachments/assets/5addbde4-8d17-4883-8660-f7ec55d92059" />
