### PR TITLE
fix(mwpw-189715): adds screen reader announcement to filter result

### DIFF
--- a/react/src/js/components/Consonant/Filters/Top/Footer.jsx
+++ b/react/src/js/components/Consonant/Filters/Top/Footer.jsx
@@ -62,7 +62,9 @@ const Footer = (props) => {
         <div
             className="consonant-TopFilter-footer">
             <span
-                className="consonant-TopFilter-footerResQty">
+                className="consonant-TopFilter-footerResQty"
+                role="status"
+                aria-live="polite">
                 {mobileGroupTotalResultsText}
             </span>
             {shouldShowClearButton &&


### PR DESCRIPTION
**Summary**
- Adds a polite live region to the top filter results quantity text.
- Allows screen readers to announce updated filter result counts without interrupting the user.

**Test**
- npm run test:unit -- react/src/js/components/Consonant/Filters/Top/__tests__/Group.spec.js 

Resolves: https://jira.corp.adobe.com/browse/MWPW-189715