### PR TITLE
feat(mwpw-194203): add data-country/data-card-url to card variants

### DIFF
--- a/react/src/js/components/Consonant/Cards/BladeCard.jsx
+++ b/react/src/js/components/Consonant/Cards/BladeCard.jsx
@@ -8,7 +8,7 @@ import LinkBlocker from './LinkBlocker/LinkBlocker';
 
 const BladeCard = () => {
     const {
-        id, lh, cardClassName, bladeVariant,
+        id, country, reference, lh, cardClassName, bladeVariant,
         optimizedImage, altText,
         hasBanner, disableBanners,
         bannerBackgroundColor, bannerFontColor, bannerIcon, bannerDescription,
@@ -29,7 +29,9 @@ const BladeCard = () => {
             daa-lh={lh}
             className={`blade-card ${cardClassName} ${bladeVariant}`}
             data-testid="consonant-Card"
-            id={id}>
+            id={id}
+            {...(country && { 'data-country': country })}
+            {...(reference && { 'data-card-url': reference })}>
             <CardHeader
                 image={optimizedImage}
                 altText={altText}

--- a/react/src/js/components/Consonant/Cards/BlogCard.jsx
+++ b/react/src/js/components/Consonant/Cards/BlogCard.jsx
@@ -8,7 +8,7 @@ import LinkBlocker from './LinkBlocker/LinkBlocker';
 
 const BlogCard = () => {
     const {
-        id, lh, cardClassName,
+        id, country, reference, lh, cardClassName,
         optimizedImage, altText,
         hasBanner, disableBanners,
         bannerBackgroundColor, bannerFontColor, bannerIcon, bannerDescription,
@@ -29,7 +29,9 @@ const BlogCard = () => {
             daa-lh={lh}
             className={`blog-card ${cardClassName}`}
             data-testid="consonant-Card"
-            id={id}>
+            id={id}
+            {...(country && { 'data-country': country })}
+            {...(reference && { 'data-card-url': reference })}>
             <CardHeader
                 image={optimizedImage}
                 altText={altText}

--- a/react/src/js/components/Consonant/Cards/ButtonCard.jsx
+++ b/react/src/js/components/Consonant/Cards/ButtonCard.jsx
@@ -5,6 +5,8 @@ import LinkBlocker from './LinkBlocker/LinkBlocker';
 const ButtonCard = () => {
     const {
         id,
+        country,
+        reference,
         lh,
         cardClassName,
         title,
@@ -19,7 +21,9 @@ const ButtonCard = () => {
             daa-lh={lh}
             className={`button-card ${cardClassName}`}
             data-testid="consonant-Card"
-            id={id}>
+            id={id}
+            {...(country && { 'data-country': country })}
+            {...(reference && { 'data-card-url': reference })}>
             <div className="consonant-Card-content">
                 <a href={overlay} className="consonant-ButtonCard-link">{cta2Text}</a>
             </div>

--- a/react/src/js/components/Consonant/Cards/Card.jsx
+++ b/react/src/js/components/Consonant/Cards/Card.jsx
@@ -93,6 +93,8 @@ const CardType = {
     origin: string,
     ariaHidden: bool,
     tabIndex: number,
+    country: string,
+    reference: string,
 };
 
 const defaultProps = {
@@ -119,11 +121,15 @@ const defaultProps = {
     origin: '',
     ariaHidden: false,
     tabIndex: 0,
+    country: '',
+    reference: '',
 };
 
 const Card = (props) => {
     const {
         id,
+        country,
+        reference,
         footer,
         lh,
         tags,
@@ -398,7 +404,7 @@ const Card = (props) => {
     const optimizedImage = optimizeImageUrl(image);
 
     const cardData = useMemo(() => ({
-        id, lh, cardClassName, cardStyle, bladeVariant,
+        id, country, reference, lh, cardClassName, cardStyle, bladeVariant,
         optimizedImage, altText, cta2Text,
         hasBanner, disableBanners,
         bannerBackgroundColor: bannerBackgroundColorToUse,

--- a/react/src/js/components/Consonant/Cards/DoubleWide.jsx
+++ b/react/src/js/components/Consonant/Cards/DoubleWide.jsx
@@ -6,7 +6,7 @@ import LinkBlocker from './LinkBlocker/LinkBlocker';
 
 const DoubleWide = () => {
     const {
-        id, lh, cardClassName,
+        id, country, reference, lh, cardClassName,
         optimizedImage, altText,
         hasBanner, disableBanners,
         bannerBackgroundColor, bannerFontColor, bannerIcon, bannerDescription,
@@ -25,7 +25,9 @@ const DoubleWide = () => {
             daa-lh={lh}
             className={`double-wide ${cardClassName}`}
             data-testid="consonant-Card"
-            id={id}>
+            id={id}
+            {...(country && { 'data-country': country })}
+            {...(reference && { 'data-card-url': reference })}>
             <CardHeader
                 image={optimizedImage}
                 altText={altText}

--- a/react/src/js/components/Consonant/Cards/EditorialCard.jsx
+++ b/react/src/js/components/Consonant/Cards/EditorialCard.jsx
@@ -8,7 +8,7 @@ import LinkBlocker from './LinkBlocker/LinkBlocker';
 
 const EditorialCard = () => {
     const {
-        id, lh, cardClassName,
+        id, country, reference, lh, cardClassName,
         optimizedImage, altText,
         hasBanner, disableBanners,
         bannerBackgroundColor, bannerFontColor, bannerIcon, bannerDescription,
@@ -29,7 +29,9 @@ const EditorialCard = () => {
             daa-lh={lh}
             className={`editorial-card ${cardClassName}`}
             data-testid="consonant-Card"
-            id={id}>
+            id={id}
+            {...(country && { 'data-country': country })}
+            {...(reference && { 'data-card-url': reference })}>
             <CardHeader
                 image={optimizedImage}
                 altText={altText}

--- a/react/src/js/components/Consonant/Cards/FullCard.jsx
+++ b/react/src/js/components/Consonant/Cards/FullCard.jsx
@@ -6,7 +6,7 @@ import LinkBlocker from './LinkBlocker/LinkBlocker';
 
 const FullCard = () => {
     const {
-        id, lh, cardClassName,
+        id, country, reference, lh, cardClassName,
         optimizedImage, altText,
         hasBanner, disableBanners,
         bannerBackgroundColor, bannerFontColor, bannerIcon, bannerDescription,
@@ -26,7 +26,9 @@ const FullCard = () => {
             daa-lh={lh}
             className={`full-card ${cardClassName}`}
             data-testid="consonant-Card"
-            id={id}>
+            id={id}
+            {...(country && { 'data-country': country })}
+            {...(reference && { 'data-card-url': reference })}>
             <CardHeader
                 image={optimizedImage}
                 altText={altText}

--- a/react/src/js/components/Consonant/Cards/HalfHeight.jsx
+++ b/react/src/js/components/Consonant/Cards/HalfHeight.jsx
@@ -7,7 +7,7 @@ import LinkBlocker from './LinkBlocker/LinkBlocker';
 
 const HalfHeight = () => {
     const {
-        id, lh, cardClassName,
+        id, country, reference, lh, cardClassName,
         optimizedImage, altText,
         hasBanner, disableBanners,
         bannerBackgroundColor, bannerFontColor, bannerIcon, bannerDescription,
@@ -26,7 +26,9 @@ const HalfHeight = () => {
             daa-lh={lh}
             className={`half-height ${cardClassName}`}
             data-testid="consonant-Card"
-            id={id}>
+            id={id}
+            {...(country && { 'data-country': country })}
+            {...(reference && { 'data-card-url': reference })}>
             <CardHeader
                 image={optimizedImage}
                 altText={altText}

--- a/react/src/js/components/Consonant/Cards/HorizontalCard.jsx
+++ b/react/src/js/components/Consonant/Cards/HorizontalCard.jsx
@@ -6,7 +6,7 @@ import LinkBlocker from './LinkBlocker/LinkBlocker';
 
 const HorizontalCard = () => {
     const {
-        id, lh, cardClassName,
+        id, country, reference, lh, cardClassName,
         optimizedImage, altText,
         hasBanner, disableBanners,
         bannerBackgroundColor, bannerFontColor, bannerIcon, bannerDescription,
@@ -23,7 +23,9 @@ const HorizontalCard = () => {
             daa-lh={lh}
             className={`horizontal-card ${cardClassName}`}
             data-testid="consonant-Card"
-            id={id}>
+            id={id}
+            {...(country && { 'data-country': country })}
+            {...(reference && { 'data-card-url': reference })}>
             <CardHeader
                 image={optimizedImage}
                 altText={altText}

--- a/react/src/js/components/Consonant/Cards/IconCard.jsx
+++ b/react/src/js/components/Consonant/Cards/IconCard.jsx
@@ -6,7 +6,7 @@ import LinkBlocker from './LinkBlocker/LinkBlocker';
 
 const IconCard = () => {
     const {
-        id, lh, cardClassName,
+        id, country, reference, lh, cardClassName,
         optimizedImage, altText,
         cardIcon, iconAlt,
         detailText,
@@ -21,7 +21,9 @@ const IconCard = () => {
             daa-lh={lh}
             className={`icon-card ${cardClassName}`}
             data-testid="consonant-Card"
-            id={id}>
+            id={id}
+            {...(country && { 'data-country': country })}
+            {...(reference && { 'data-card-url': reference })}>
             <CardHeader
                 image={optimizedImage}
                 altText={altText}

--- a/react/src/js/components/Consonant/Cards/NewsCard.jsx
+++ b/react/src/js/components/Consonant/Cards/NewsCard.jsx
@@ -8,7 +8,7 @@ import LinkBlocker from './LinkBlocker/LinkBlocker';
 
 const NewsCard = () => {
     const {
-        id, lh, cardClassName,
+        id, country, reference, lh, cardClassName,
         optimizedImage, altText,
         videoURL, videoURLToUse, gateVideo, useCenterVideoPlay,
         detailText,
@@ -26,7 +26,9 @@ const NewsCard = () => {
             daa-lh={lh}
             className={`news-card ${cardClassName}`}
             data-testid="consonant-Card"
-            id={id}>
+            id={id}
+            {...(country && { 'data-country': country })}
+            {...(reference && { 'data-card-url': reference })}>
             <CardHeader
                 image={optimizedImage}
                 altText={altText}

--- a/react/src/js/components/Consonant/Cards/OneHalf.jsx
+++ b/react/src/js/components/Consonant/Cards/OneHalf.jsx
@@ -8,7 +8,7 @@ import LinkBlocker from './LinkBlocker/LinkBlocker';
 
 const OneHalf = () => {
     const {
-        id, lh, cardClassName,
+        id, country, reference, lh, cardClassName,
         optimizedImage, altText,
         hasBanner, disableBanners,
         bannerBackgroundColor, bannerFontColor, bannerIcon, bannerDescription,
@@ -31,7 +31,9 @@ const OneHalf = () => {
             daa-lh={lh}
             className={`one-half ${cardClassName}`}
             data-testid="consonant-Card"
-            id={id}>
+            id={id}
+            {...(country && { 'data-country': country })}
+            {...(reference && { 'data-card-url': reference })}>
             <CardHeader
                 image={optimizedImage}
                 altText={altText}

--- a/react/src/js/components/Consonant/Cards/Product.jsx
+++ b/react/src/js/components/Consonant/Cards/Product.jsx
@@ -7,7 +7,7 @@ import LinkBlocker from './LinkBlocker/LinkBlocker';
 
 const Product = () => {
     const {
-        id, lh, cardClassName,
+        id, country, reference, lh, cardClassName,
         highlightedTitle, title, headingAria, headingLevel,
         highlightedDescription, description,
         parseMarkDown,
@@ -23,7 +23,9 @@ const Product = () => {
             daa-lh={lh}
             className={`product ${cardClassName}`}
             data-testid="consonant-Card"
-            id={id}>
+            id={id}
+            {...(country && { 'data-country': country })}
+            {...(reference && { 'data-card-url': reference })}>
             <div className="consonant-Card-content">
                 <CardContent
                     showLabel={false}

--- a/react/src/js/components/Consonant/Cards/TextCard.jsx
+++ b/react/src/js/components/Consonant/Cards/TextCard.jsx
@@ -8,7 +8,7 @@ import LinkBlocker from './LinkBlocker/LinkBlocker';
 
 const TextCard = () => {
     const {
-        id, lh, cardClassName,
+        id, country, reference, lh, cardClassName,
         optimizedImage, altText,
         hasBanner, disableBanners,
         bannerBackgroundColor, bannerFontColor, bannerIcon, bannerDescription,
@@ -28,7 +28,9 @@ const TextCard = () => {
             daa-lh={lh}
             className={`text-card ${cardClassName}`}
             data-testid="consonant-Card"
-            id={id}>
+            id={id}
+            {...(country && { 'data-country': country })}
+            {...(reference && { 'data-card-url': reference })}>
             <CardHeader
                 image={optimizedImage}
                 altText={altText}

--- a/react/src/js/components/Consonant/Cards/ThreeFourths.jsx
+++ b/react/src/js/components/Consonant/Cards/ThreeFourths.jsx
@@ -6,7 +6,7 @@ import LinkBlocker from './LinkBlocker/LinkBlocker';
 
 const ThreeFourths = () => {
     const {
-        id, lh, cardClassName,
+        id, country, reference, lh, cardClassName,
         optimizedImage, altText,
         hasBanner, disableBanners,
         bannerBackgroundColor, bannerFontColor, bannerIcon, bannerDescription,
@@ -27,7 +27,9 @@ const ThreeFourths = () => {
             daa-lh={lh}
             className={`three-fourths ${cardClassName}`}
             data-testid="consonant-Card"
-            id={id}>
+            id={id}
+            {...(country && { 'data-country': country })}
+            {...(reference && { 'data-card-url': reference })}>
             <CardHeader
                 image={optimizedImage}
                 altText={altText}

--- a/react/src/js/components/Consonant/Cards/__tests__/Card.spec.js
+++ b/react/src/js/components/Consonant/Cards/__tests__/Card.spec.js
@@ -143,3 +143,33 @@ describe('Card Component - Specific Conditions', () => {
         expect(descriptionTextElement).toHaveTextContent('This is a bold and italic text.');
     });
 });
+
+describe('MEP debug attributes for Hightlight CaaS feature', () => {
+    const cardStyles = [
+        'one-half', 'three-fourths', 'double-wide', 'half-height',
+        'product', 'text-card', 'full-card', 'icon-card', 'news-card',
+        'blade-card', 'editorial-card', 'blog-card', 'horizontal-card',
+        'button-card',
+    ];
+
+    test.each(cardStyles)('%s stamps data-country and data-card-url when populated', (cardStyle) => {
+        renderCard({
+            cardStyle,
+            country: 'us',
+            reference: 'https://business.adobe.com/customer-success-stories/foo.html',
+        });
+        const li = screen.getByTestId('consonant-Card');
+        expect(li).toHaveAttribute('data-country', 'us');
+        expect(li).toHaveAttribute(
+            'data-card-url',
+            'https://business.adobe.com/customer-success-stories/foo.html',
+        );
+    });
+
+    test('omits data-country and data-card-url when both are empty', () => {
+        renderCard({ cardStyle: 'one-half' });
+        const li = screen.getByTestId('consonant-Card');
+        expect(li).not.toHaveAttribute('data-country');
+        expect(li).not.toHaveAttribute('data-card-url');
+    });
+});


### PR DESCRIPTION
## Summary
Surface two read-only data attributes on every CaaS card's root `<li>` so Milo's MEP debug "Highlight CaaS" feature can identify regional vs. fallback content and provide a click-through target. No runtime behaviour changes for any current consumer.
- **`data-country`** — populated from the existing `country` field on the Chimera response (e.g. `"us"`, `"xx"`).
- **`data-card-url`** — populated from the existing `reference` field on the Chimera response (the canonical content URL).
Both attributes are emitted only when the corresponding value is truthy, so empty defaults don't add DOM noise.
## Why


The two new data attributes will be consumed by a separate Milo PR to power a new MEP feature, **Highlight CaaS**, shown below:

<img width="2146" height="982" alt="Screenshot 2026-05-07 at 2 18 34 PM" src="https://github.com/user-attachments/assets/654c37c8-aa47-4cf0-8906-da8b1fbfc08e" />

