### PR TITLE
fix(mwpw-195429): pin Chrome binary path in wdio configs to unblock E2E

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -141,6 +141,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Chrome
+        id: setup-chrome
         uses: browser-actions/setup-chrome@v1
         with:
           # Pinned to 146 to match chromedriver@^146.0.5 from package.json.
@@ -154,6 +155,11 @@ jobs:
         run: npm ci
       - name: E2E
         run: npm run test:e2e-prod
+        env:
+          # Pin the Chrome binary path to the version installed above.
+          # The ubuntu-latest runner ships a newer system Chrome at
+          # /opt/google/chrome/chrome that chromedriver@146 cannot drive.
+          CHROME_BIN: ${{ steps.setup-chrome.outputs.chrome-path }}
   run-bulk-publisher-e2e:
     runs-on: ubuntu-latest
     # Skip for Dependabot PRs — secrets are withheld by GitHub for Dependabot-triggered workflows
@@ -162,6 +168,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Chrome
+        id: setup-chrome
         uses: browser-actions/setup-chrome@v1
         with:
           # Pinned to 146 to match chromedriver@^146.0.5 from package.json.
@@ -177,6 +184,10 @@ jobs:
         run: npm run test:bulk-publisher
         env:
           IMS_CLIENT_SECRET: ${{ secrets.IMS_CLIENT_SECRET }}
+          # Pin the Chrome binary path to the version installed above.
+          # The ubuntu-latest runner ships a newer system Chrome at
+          # /opt/google/chrome/chrome that chromedriver@146 cannot drive.
+          CHROME_BIN: ${{ steps.setup-chrome.outputs.chrome-path }}
 
   run-accessibility-checks:
     runs-on: ubuntu-latest

--- a/wdio.bulk-publisher.conf.js
+++ b/wdio.bulk-publisher.conf.js
@@ -9,6 +9,13 @@ exports.config = {
         browserName: 'chrome',
         acceptInsecureCerts: true,
         'goog:chromeOptions': {
+            // Pin the Chrome binary to the version set up by the workflow's
+            // browser-actions/setup-chrome step. Without this, chromedriver
+            // falls back to the runner's system Chrome (whose version drifts
+            // with the ubuntu-latest image rotation) and fails with
+            // "session not created: This version of ChromeDriver only
+            // supports Chrome version <N>" when it doesn't match.
+            ...(process.env.CHROME_BIN ? { binary: process.env.CHROME_BIN } : {}),
             args: [
                 '--no-sandbox',
                 '--headless',

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -12,6 +12,13 @@ exports.config = {
         browserName: 'chrome',
         acceptInsecureCerts: true,
         'goog:chromeOptions': {
+            // Pin the Chrome binary to the version set up by the workflow's
+            // browser-actions/setup-chrome step. Without this, chromedriver
+            // falls back to the runner's system Chrome (whose version drifts
+            // with the ubuntu-latest image rotation) and fails with
+            // "session not created: This version of ChromeDriver only
+            // supports Chrome version <N>" when it doesn't match.
+            ...(process.env.CHROME_BIN ? { binary: process.env.CHROME_BIN } : {}),
             args: [
                 '--no-sandbox',
                 '--disable-infobars',


### PR DESCRIPTION
Both run-e2e-tests and run-bulk-publisher-e2e were failing on PRs because GitHub rotated the ubuntu-latest runner image and the preinstalled system Chrome at /opt/google/chrome/chrome is now 148.0.7778.x, while the lockfile pins chromedriver to 146.0.5 (which can only drive Chrome 146).

The 'browser-actions/setup-chrome@v1' step does install Chrome 146 into a separate cache path, but neither wdio config tells webdriverio to use that binary. Both jobs therefore fall through to the system Chrome on PATH and fail with:

  session not created: This version of ChromeDriver only supports
  Chrome version 146
  Current browser version is 148.0.7778.167 with binary path
  /opt/google/chrome/chrome

Fix: capture the action's 'chrome-path' output via a step id, export it as CHROME_BIN on the test invocation, and have both wdio configs pin 'goog:chromeOptions.binary' to process.env.CHROME_BIN when set. The spread-conditional pattern keeps local development working unchanged (no CHROME_BIN env -> no override -> default Chrome discovery).

run-e2e-tests has so far been incidentally passing because PATH resolution under Node 16 happens to prefer the action-installed Chrome on this runner image, but the same drift will break it on the next image rotation, so applying the fix to wdio.conf.js too for resilience.

Affects: every open PR in adobecom/caas. PR #458 (docs-only) exposed the breakage.