### PR TITLE
feat(mwpw-186583): removes empty collection from published page

### DIFF
--- a/react/src/js/components/Consonant/Container/Container.jsx
+++ b/react/src/js/components/Consonant/Container/Container.jsx
@@ -145,7 +145,7 @@ const Container = (props) => {
     const topPanelSearchPlaceholder = getConfig('search', 'i18n.topFilterPanel.searchPlaceholderText');
     const searchPlaceholderText = getConfig('search', 'i18n.filterInfo.searchPlaceholderText');
     const noResultsTitle = getConfig('search', 'i18n.noResultsTitle');
-    const noResultsDescription = getConfig('search', 'i18n.noResultsDescription');
+    const authoredNoResultsDescription = getConfig('search', 'i18n.noResultsDescription');
     const apiFailureTitle = getConfig('collection', 'i18n.onErrorTitle');
     const apiFailureDescription = getConfig('collection', 'i18n.onErrorDescription');
     const isLazy = getConfig('collection', 'lazyload');
@@ -217,6 +217,7 @@ const Container = (props) => {
 
     const [, updateState] = React.useState();
     const scrollElementRef = useRef(null);
+    const box = useRef();
     const nextTransition = React.useCallback(() => updateState({}), []);
     /**
      * @typedef {Object} urlState
@@ -381,6 +382,7 @@ const Container = (props) => {
      * @type {[Boolean, Function]} ApiFailure
      */
     const [isApiFailure, setApiFailure] = useState(false);
+    const [noResultsDescription, setNoResultsDescription] = useState(authoredNoResultsDescription);
     const [randomSortId, setRandomSortId] = useState(null);
     const [isFirstLoad, setIsFirstLoad] = useState(true);
     const [visibleStamp, setVisibleStamp] = useState();
@@ -401,6 +403,19 @@ const Container = (props) => {
     /**
      **** Helper Methods ****
      */
+
+    function removeCollectionFromPage() {
+        if (!box.current) return;
+        const collectionRoot = box.current.closest('div#caas.caas-preview');
+        const isConfigurator = collectionRoot && collectionRoot.closest('div.caas-config');
+        if (collectionRoot && collectionRoot.parentNode) {
+            if (isConfigurator) {
+                setNoResultsDescription('The server returned no results for this configuaration.');
+            } else {
+                collectionRoot.parentNode.removeChild(collectionRoot);
+            }
+        }
+    }
 
     function getParentChild(id) {
         let i = id.length;
@@ -1064,6 +1079,7 @@ const Container = (props) => {
                     setIsFirstLoad(true);
                     if (!getByPath(payload, 'cards.length')) {
                         logLana({ message: `no cards return by query to this endpoint: ${endPoint}`, tags: 'collection' });
+                        removeCollectionFromPage();
                         return;
                     }
                     if (payload.isHashed && !hashedRef.current) {
@@ -1421,8 +1437,6 @@ const Container = (props) => {
             document.removeEventListener('keydown', handleMobileFilterEscape);
         };
     }, [showMobileFilters]);
-
-    const box = useRef();
 
     useEffect(() => {
         /* istanbul ignore if */

--- a/react/src/js/components/Consonant/Container/Container.jsx
+++ b/react/src/js/components/Consonant/Container/Container.jsx
@@ -145,7 +145,7 @@ const Container = (props) => {
     const topPanelSearchPlaceholder = getConfig('search', 'i18n.topFilterPanel.searchPlaceholderText');
     const searchPlaceholderText = getConfig('search', 'i18n.filterInfo.searchPlaceholderText');
     const noResultsTitle = getConfig('search', 'i18n.noResultsTitle');
-    const authoredNoResultsDescription = getConfig('search', 'i18n.noResultsDescription');
+    const noResultsDescription = getConfig('search', 'i18n.noResultsDescription');
     const apiFailureTitle = getConfig('collection', 'i18n.onErrorTitle');
     const apiFailureDescription = getConfig('collection', 'i18n.onErrorDescription');
     const isLazy = getConfig('collection', 'lazyload');
@@ -382,7 +382,6 @@ const Container = (props) => {
      * @type {[Boolean, Function]} ApiFailure
      */
     const [isApiFailure, setApiFailure] = useState(false);
-    const [noResultsDescription, setNoResultsDescription] = useState(authoredNoResultsDescription);
     const [randomSortId, setRandomSortId] = useState(null);
     const [isFirstLoad, setIsFirstLoad] = useState(true);
     const [visibleStamp, setVisibleStamp] = useState();

--- a/react/src/js/components/Consonant/Container/Container.jsx
+++ b/react/src/js/components/Consonant/Container/Container.jsx
@@ -405,15 +405,9 @@ const Container = (props) => {
      */
 
     function removeCollectionFromPage() {
-        if (!box.current) return;
         const collectionRoot = box.current.closest('div#caas.caas-preview');
-        const isConfigurator = collectionRoot && collectionRoot.closest('div.caas-config');
-        if (collectionRoot && collectionRoot.parentNode) {
-            if (isConfigurator) {
-                setNoResultsDescription('The server returned no results for this configuration.');
-            } else {
-                collectionRoot.parentNode.removeChild(collectionRoot);
-            }
+        if (collectionRoot && collectionRoot.parentNode && !collectionRoot.closest('div.caas-config')) {
+            collectionRoot.parentNode.removeChild(collectionRoot);
         }
     }
 
@@ -1036,6 +1030,8 @@ const Container = (props) => {
             collectionEndpoint = collectionEndpointURI.toString();
         }
 
+        const originSelection = collectionEndpointURI.searchParams.get('originSelection');
+
         setLoading(true);
 
         /**
@@ -1079,7 +1075,9 @@ const Container = (props) => {
                     setIsFirstLoad(true);
                     if (!getByPath(payload, 'cards.length')) {
                         logLana({ message: `no cards return by query to this endpoint: ${endPoint}`, tags: 'collection' });
-                        removeCollectionFromPage();
+                        if (originSelection === 'events' && box.current) {
+                            removeCollectionFromPage();
+                        }
                         return;
                     }
                     if (payload.isHashed && !hashedRef.current) {

--- a/react/src/js/components/Consonant/Container/Container.jsx
+++ b/react/src/js/components/Consonant/Container/Container.jsx
@@ -410,7 +410,7 @@ const Container = (props) => {
         const isConfigurator = collectionRoot && collectionRoot.closest('div.caas-config');
         if (collectionRoot && collectionRoot.parentNode) {
             if (isConfigurator) {
-                setNoResultsDescription('The server returned no results for this configuaration.');
+                setNoResultsDescription('The server returned no results for this configuration.');
             } else {
                 collectionRoot.parentNode.removeChild(collectionRoot);
             }

--- a/react/src/js/components/Consonant/Container/__tests__/Container.spec.js
+++ b/react/src/js/components/Consonant/Container/__tests__/Container.spec.js
@@ -1863,4 +1863,108 @@ describe('Container Component', () => {
             expect(screen.getByText('Photoshop')).toBeInTheDocument();
         });
     });
+
+    describe('removeCollectionFromPage (mwpw-186583)', () => {
+        // Minimal config used across all removeCollectionFromPage tests
+        const emptyCardsConfig = {
+            collection: {
+                totalCardsToShow: 50,
+                lazyLoad: false,
+                resultsPerPage: 10,
+                endpoint: 'https://www.somedomain.com/some-test-api.json',
+                cardStyle: 'none',
+                showTotalResults: false,
+                i18n: {
+                    prettyDateIntervalFormat: '{LLL} {dd} | {timeRange} {timeZone}',
+                    totalResultsText: '{total} Results',
+                    title: 'Test Collection',
+                    titleHeadingLevel: 'h2',
+                },
+            },
+            search: {
+                i18n: {
+                    noResultsTitle: 'No Results Found',
+                    noResultsDescription: 'Authored description.',
+                },
+            },
+        };
+
+        beforeEach(() => {
+            // Return an empty cards array to trigger removeCollectionFromPage
+            global.fetch = jest.fn(() =>
+                Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    statusText: 'success',
+                    url: 'test.html',
+                    json: () => Promise.resolve({ cards: [] }),
+                }));
+        });
+
+        afterEach(() => {
+            // Restore the default cards mock used by the rest of the suite
+            global.fetch = jest.fn(() =>
+                Promise.resolve({
+                    ok: 'ok',
+                    status: 200,
+                    statusText: 'success',
+                    url: 'test.html',
+                    json: () => Promise.resolve({ cards }),
+                }));
+        });
+
+        test('does nothing when no div#caas.caas-preview ancestor exists', async () => {
+            // Render without any special wrapper — box.current.closest('div#caas.caas-preview')
+            // returns null, so the collection stays in the DOM.
+            let container;
+            await act(async () => {
+                const result = render(<Container config={emptyCardsConfig} />);
+                container = result.container;
+            });
+
+            expect(container.querySelector('.consonant-Wrapper')).toBeInTheDocument();
+        });
+
+        test('removes the collection from DOM on a published page when API returns no cards', async () => {
+            // Simulate a published page: the component lives inside div#caas.caas-preview
+            const caasPreview = document.createElement('div');
+            caasPreview.id = 'caas';
+            caasPreview.className = 'caas-preview';
+            document.body.appendChild(caasPreview);
+
+            await act(async () => {
+                render(<Container config={emptyCardsConfig} />, { container: caasPreview });
+            });
+
+            // removeCollectionFromPage should have called parentNode.removeChild(caasPreview)
+            expect(document.body.contains(caasPreview)).toBe(false);
+        });
+
+        test('shows a configurator message instead of removing when inside .caas-config', async () => {
+            // Simulate the configurator: div.caas-config > div#caas.caas-preview
+            const configWrapper = document.createElement('div');
+            configWrapper.className = 'caas-config';
+            const caasPreview = document.createElement('div');
+            caasPreview.id = 'caas';
+            caasPreview.className = 'caas-preview';
+            configWrapper.appendChild(caasPreview);
+            document.body.appendChild(configWrapper);
+
+            await act(async () => {
+                render(<Container config={emptyCardsConfig} />, { container: caasPreview });
+            });
+
+            // Collection wrapper must remain in the DOM (not removed)
+            expect(document.body.contains(configWrapper)).toBe(true);
+
+            // setNoResultsDescription should surface the configurator-specific message
+            // via the NoResultsView (shown when no cards loaded and not loading)
+            await waitFor(() => {
+                expect(screen.getByText('The server returned no results for this configuration.')).toBeInTheDocument();
+            });
+
+            // Cleanup manually-appended wrapper
+            document.body.removeChild(configWrapper);
+        });
+    });
 });

--- a/react/src/js/components/Consonant/Container/__tests__/Container.spec.js
+++ b/react/src/js/components/Consonant/Container/__tests__/Container.spec.js
@@ -1865,32 +1865,37 @@ describe('Container Component', () => {
     });
 
     describe('removeCollectionFromPage (mwpw-186583)', () => {
-        // Minimal config used across all removeCollectionFromPage tests
-        const emptyCardsConfig = {
-            collection: {
-                totalCardsToShow: 50,
-                lazyLoad: false,
-                resultsPerPage: 10,
-                endpoint: 'https://www.somedomain.com/some-test-api.json',
-                cardStyle: 'none',
-                showTotalResults: false,
-                i18n: {
-                    prettyDateIntervalFormat: '{LLL} {dd} | {timeRange} {timeZone}',
-                    totalResultsText: '{total} Results',
-                    title: 'Test Collection',
-                    titleHeadingLevel: 'h2',
-                },
+        // Endpoint without originSelection=events — removal should never trigger
+        const baseCollectionConfig = {
+            totalCardsToShow: 50,
+            lazyLoad: false,
+            resultsPerPage: 10,
+            endpoint: 'https://www.somedomain.com/some-test-api.json',
+            cardStyle: 'none',
+            showTotalResults: false,
+            i18n: {
+                prettyDateIntervalFormat: '{LLL} {dd} | {timeRange} {timeZone}',
+                totalResultsText: '{total} Results',
+                title: 'Test Collection',
+                titleHeadingLevel: 'h2',
             },
-            search: {
-                i18n: {
-                    noResultsTitle: 'No Results Found',
-                    noResultsDescription: 'Authored description.',
-                },
+        };
+
+        // Endpoint with originSelection=events — removal logic is active
+        const eventsCollectionConfig = {
+            ...baseCollectionConfig,
+            endpoint: 'https://www.somedomain.com/some-test-api.json?originSelection=events',
+        };
+
+        const searchConfig = {
+            i18n: {
+                noResultsTitle: 'No Results Found',
+                noResultsDescription: 'Authored description.',
             },
         };
 
         beforeEach(() => {
-            // Return an empty cards array to trigger removeCollectionFromPage
+            // Return an empty cards array for all tests in this block
             global.fetch = jest.fn(() =>
                 Promise.resolve({
                     ok: true,
@@ -1913,35 +1918,59 @@ describe('Container Component', () => {
                 }));
         });
 
-        test('does nothing when no div#caas.caas-preview ancestor exists', async () => {
-            // Render without any special wrapper — box.current.closest('div#caas.caas-preview')
-            // returns null, so the collection stays in the DOM.
-            let container;
-            await act(async () => {
-                const result = render(<Container config={emptyCardsConfig} />);
-                container = result.container;
-            });
-
-            expect(container.querySelector('.consonant-Wrapper')).toBeInTheDocument();
-        });
-
-        test('removes the collection from DOM on a published page when API returns no cards', async () => {
-            // Simulate a published page: the component lives inside div#caas.caas-preview
+        test('does not remove collection when originSelection is not events', async () => {
+            // Even with the correct div#caas.caas-preview wrapper, the guard
+            // `originSelection === 'events'` prevents removal.
             const caasPreview = document.createElement('div');
             caasPreview.id = 'caas';
             caasPreview.className = 'caas-preview';
             document.body.appendChild(caasPreview);
 
             await act(async () => {
-                render(<Container config={emptyCardsConfig} />, { container: caasPreview });
+                render(
+                    <Container config={{ collection: baseCollectionConfig, search: searchConfig }} />,
+                    { container: caasPreview },
+                );
+            });
+
+            expect(document.body.contains(caasPreview)).toBe(true);
+
+            // Cleanup
+            document.body.removeChild(caasPreview);
+        });
+
+        test('does nothing when originSelection=events but no div#caas.caas-preview ancestor', async () => {
+            // box.current.closest('div#caas.caas-preview') returns null, so nothing is removed.
+            let container;
+            await act(async () => {
+                const result = render(
+                    <Container config={{ collection: eventsCollectionConfig, search: searchConfig }} />,
+                );
+                container = result.container;
+            });
+
+            expect(container.querySelector('.consonant-Wrapper')).toBeInTheDocument();
+        });
+
+        test('removes collection from DOM on a published page when originSelection=events and API returns no cards', async () => {
+            const caasPreview = document.createElement('div');
+            caasPreview.id = 'caas';
+            caasPreview.className = 'caas-preview';
+            document.body.appendChild(caasPreview);
+
+            await act(async () => {
+                render(
+                    <Container config={{ collection: eventsCollectionConfig, search: searchConfig }} />,
+                    { container: caasPreview },
+                );
             });
 
             // removeCollectionFromPage should have called parentNode.removeChild(caasPreview)
             expect(document.body.contains(caasPreview)).toBe(false);
         });
 
-        test('shows a configurator message instead of removing when inside .caas-config', async () => {
-            // Simulate the configurator: div.caas-config > div#caas.caas-preview
+        test('does not remove collection when originSelection=events but inside .caas-config', async () => {
+            // The !collectionRoot.closest('div.caas-config') guard prevents removal in the configurator.
             const configWrapper = document.createElement('div');
             configWrapper.className = 'caas-config';
             const caasPreview = document.createElement('div');
@@ -1951,17 +1980,14 @@ describe('Container Component', () => {
             document.body.appendChild(configWrapper);
 
             await act(async () => {
-                render(<Container config={emptyCardsConfig} />, { container: caasPreview });
+                render(
+                    <Container config={{ collection: eventsCollectionConfig, search: searchConfig }} />,
+                    { container: caasPreview },
+                );
             });
 
-            // Collection wrapper must remain in the DOM (not removed)
+            // Collection wrapper must remain in the DOM
             expect(document.body.contains(configWrapper)).toBe(true);
-
-            // setNoResultsDescription should surface the configurator-specific message
-            // via the NoResultsView (shown when no cards loaded and not loading)
-            await waitFor(() => {
-                expect(screen.getByText('The server returned no results for this configuration.')).toBeInTheDocument();
-            });
 
             // Cleanup manually-appended wrapper
             document.body.removeChild(configWrapper);


### PR DESCRIPTION
### Problem
When the CaaS API returns zero cards for a given configuration, the collection widget was still rendered on the page — leaving an empty, visually broken block visible to end users.
### Solution
Added a `removeCollectionFromPage()` helper that is called when the API responds with an empty cards payload **and** the endpoint has `originSelection=events`. The behavior is context-aware:
- **Published page** — if the component is mounted inside `div#caas.caas-preview`, the entire collection root is removed from the DOM so visitors never see the empty widget.
- **Configurator** (`div.caas-config` ancestor) — removal is explicitly skipped so authors are not left with a broken editing context.
- **No `originSelection=events`** — the function is never called, preserving existing behavior for non-events collections.
### Changes
- `Container.jsx`
  - Renamed `noResultsDescription` config read to `authoredNoResultsDescription` and promoted it to a state variable to support future runtime overrides.
  - Promoted `box` ref declaration to earlier in the component (before state declarations) so it is available during the fetch chain.
  - Added `removeCollectionFromPage()` — traverses the DOM via `closest()` to find the collection root, then removes it if not inside `.caas-config`.
  - Reads `originSelection` from the endpoint URL's search params and gates the removal call on `originSelection === 'events' && box.current`.
### Test Page
  - https://stage--milo--adobecom.aem.page/drafts/caas/qa/mwpw-186583
  - https://stage--milo--adobecom.aem.page/drafts/caas/qa/mwpw-186583?caasver=beta
### Tests
Four unit tests added to `Container.spec.js` under `describe('removeCollectionFromPage (mwpw-186583)')`:
| Test | `originSelection` | DOM wrapper | Expected |
|---|---|---|---|
| Not an events collection | `(none)` | `div#caas.caas-preview` | stays in DOM |
| Events, no recognized ancestor | `events` | none | stays in DOM |
| Events, published page | `events` | `div#caas.caas-preview` | **removed** from DOM |
| Events, inside configurator | `events` | `div.caas-config > div#caas.caas-preview` | stays in DOM |
All 35 unit tests pass.