### PR TITLE
fix(mwpw-195429): pin Chrome binary in scheduled bulk-publisher e2e

### DIFF
--- a/.github/workflows/bulk-publisher-e2e-scheduled.yml
+++ b/.github/workflows/bulk-publisher-e2e-scheduled.yml
@@ -11,6 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Chrome
+        id: setup-chrome
         uses: browser-actions/setup-chrome@v1
         with:
           # Pinned to Chrome 146 to match the chromedriver@^146.0.5 version in
@@ -28,6 +29,12 @@ jobs:
         run: npm run test:bulk-publisher
         env:
           IMS_CLIENT_SECRET: ${{ secrets.IMS_CLIENT_SECRET }}
+          # Pin the Chrome binary path to the version installed above.
+          # The ubuntu-latest runner ships a newer system Chrome at
+          # /opt/google/chrome/chrome that chromedriver@146 cannot drive.
+          # Mirrors the pin already in place for the PR-triggered workflow
+          # (see .github/workflows/pull-request.yaml, PR #461 / MWPW-195429).
+          CHROME_BIN: ${{ steps.setup-chrome.outputs.chrome-path }}
 
       - name: Open issue on failure
         if: failure()


### PR DESCRIPTION
PR #461 (MWPW-195429) pinned the Chrome binary path through `CHROME_BIN` for the PR-triggered workflow, but the scheduled cron workflow `.github/workflows/bulk-publisher-e2e-scheduled.yml` was not updated. The wdio configs gate the binary pin behind `process.env.CHROME_BIN`, so without that env var exported the conditional collapses to an empty object and chromedriver reverts to the runner's drift-prone system Chrome — reproducing the original failure mode and opening daily issues like #466.

This change applies the same two additions PR #461 made to `pull-request.yaml`:

- adds `id: setup-chrome` to the Setup Chrome step
- passes `CHROME_BIN: ${{ steps.setup-chrome.outputs.chrome-path }}` through the `env:` block of the test step

Closes #466.
