### PR TITLE
fix(mwpw-196902): install playwright + treat NO_VERDICT as fail

### DIFF
--- a/.github/qa/package-lock.json
+++ b/.github/qa/package-lock.json
@@ -1,0 +1,56 @@
+{
+  "name": "caas-qa-audit-runner",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "caas-qa-audit-runner",
+      "version": "1.0.0",
+      "dependencies": {
+        "playwright": "^1.48.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/.github/qa/package.json
+++ b/.github/qa/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "caas-qa-audit-runner",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Playwright + tooling for the AI-driven QA audit workflow. Isolated from the main CaaS package.json so adding/upgrading Playwright doesn't touch the React build.",
+  "type": "module",
+  "dependencies": {
+    "playwright": "^1.48.0"
+  }
+}

--- a/.github/workflows/qa-audit.yml
+++ b/.github/workflows/qa-audit.yml
@@ -51,6 +51,15 @@ jobs:
           node --version
           which magick || echo "ImageMagick not installed - diff_screenshots will skip"
 
+      - name: Install Playwright (isolated from main package.json)
+        # The CaaS project uses WebdriverIO for e2e; Playwright is QA-audit-specific
+        # and lives in its own package.json under .github/qa/ to avoid polluting
+        # the React build dependency tree.
+        working-directory: .github/qa
+        run: |
+          npm ci --no-audit --no-fund
+          npx playwright install chromium --with-deps 2>&1 | tail -5 || true
+
       - name: Run audit suite
         id: run
         env:
@@ -77,8 +86,10 @@ jobs:
           fi
           echo "Aggregating from: $RESULTS_DIR"
           node .github/qa/aggregate-report.mjs "$RESULTS_DIR" > /tmp/qa-audit-report.md
-          # Strip "FAIL_INCOMPLETE" from grep target since aggregate treats them as fail.
-          if grep -qE '\| (FAIL|INCOMPLETE) \|' /tmp/qa-audit-report.md; then
+          # Any non-PASS verdict per row (FAIL / INCOMPLETE / NO_VERDICT) flips
+          # the overall to FAIL. Also catch the per-row pipe-separated tags from
+          # the aggregator's summary table.
+          if grep -qE '\| (FAIL|INCOMPLETE|NO_VERDICT) \|' /tmp/qa-audit-report.md; then
             echo "verdict=FAIL" >> "$GITHUB_OUTPUT"
           else
             echo "verdict=PASS" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What

Fixes two bugs discovered on the first real run of the QA Audit workflow (#477, triggered at run [26706127922](https://github.com/adobecom/caas/actions/runs/26706127922)).

## Bug 1: Playwright not installed in CI environment

The workflow checked out the repo at `_work/caas/caas/` and ran `qa-runner-v2.mjs` directly. The runner needs `playwright` as an ES module import. CaaS uses WebdriverIO for e2e tests, so `playwright` is not a project dep. All 8 scenarios crashed immediately with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'playwright' imported from
/Users/sanjayrai/actions-runner-qa-audit/_work/caas/caas/.github/qa/qa-runner-v2.mjs
```

**Fix:** isolated `.github/qa/package.json` with `playwright` as the sole dep. Workflow now runs `npm ci` + `npx playwright install chromium --with-deps` inside `.github/qa/` before invoking the audit suite. Keeps the main React build's dependency tree untouched.

## Bug 2: NO_VERDICT scenarios reported as overall PASS

The aggregate-report's summary table shows each scenario's verdict as one of `PASS`, `FAIL`, `FAIL_INCOMPLETE`, or `NO_VERDICT`. The previous verdict-detection grep matched only `FAIL` and `INCOMPLETE`:

```
grep -qE '\| (FAIL|INCOMPLETE) \|' /tmp/qa-audit-report.md
```

When all 8 scenarios crashed early (bug 1), every row was `| NO_VERDICT |`, the grep didn't match, and the workflow falsely reported `PASS`. That produced [Issue #480](https://github.com/adobecom/caas/issues/480) with a misleading "passed" report.

**Fix:** grep now includes `NO_VERDICT`:

```
grep -qE '\| (FAIL|INCOMPLETE|NO_VERDICT) \|' /tmp/qa-audit-report.md
```

Any non-PASS row in the summary table now correctly flips the overall verdict to FAIL.

## Validation

After these two fixes, re-trigger `QA Audit` from the Actions tab with `caasver=0.45.0` and confirm:
- Job completes in ~7-10 minutes (not 31 seconds — that was the all-crash signature)
- Posted Issue shows actual PASS/FAIL verdicts per scenario, not all `NO_VERDICT`
- Workflow conclusion correctly reflects findings

## Cleanup

- [Issue #480](https://github.com/adobecom/caas/issues/480) should be closed (false positive from the broken run). Recommend a comment like "Closing — workflow had two bugs that made this a false PASS; see #<this PR> for fixes."
