### PR TITLE
chore: bump CI Node.js to 24 (Kodiak EOL finding)

### DIFF
--- a/.github/workflows/bulk-publisher-e2e-scheduled.yml
+++ b/.github/workflows/bulk-publisher-e2e-scheduled.yml
@@ -22,7 +22,7 @@ jobs:
           chrome-version: '146'
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 24
       - name: Install
         run: npm ci
       - name: Run Bulk Publisher E2E Tests

--- a/.github/workflows/manual-build-release.yml
+++ b/.github/workflows/manual-build-release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 24
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -24,7 +24,7 @@ jobs:
           token: ${{ secrets.BOT_TOKEN || secrets.WORKFLOW_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.1
+          node-version: 24
       - name: git config
         run: |
           git config user.name "${GITHUB_ACTOR}"
@@ -75,7 +75,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.1
+          node-version: 24
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/point-release.yml
+++ b/.github/workflows/point-release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '24'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.1
+          node-version: 24
           cache: 'npm'
       - run: npm ci
       - name: Check PR title
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.1
+          node-version: 24
       - name: Install dependencies
         run: npm install @actions/core @actions/github
       - name: Check PR Type and Tests
@@ -44,7 +44,7 @@ jobs:
       uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16.13.1
+        node-version: 24
         cache: 'npm'
     - name: Install
       run: npm ci
@@ -57,7 +57,7 @@ jobs:
       uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16.13.1
+        node-version: 24
         cache: 'npm'
     - name: Install
       run: npm ci
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 24
           cache: 'npm'
       - name: Install
         run: npm ci
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 24
           cache: 'npm'
       - name: Install
         run: npm ci
@@ -104,7 +104,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 24
 
       # 3. Install dependencies
       - name: Install dependencies
@@ -150,7 +150,7 @@ jobs:
           chrome-version: '146'
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.1
+          node-version: 24
       - name: Install
         run: npm ci
       - name: E2E
@@ -177,7 +177,7 @@ jobs:
           chrome-version: '146'
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 24
       - name: Install
         run: npm ci
       - name: Run Bulk Publisher E2E Tests
@@ -197,7 +197,7 @@ jobs:
       - name: Use Node.js 18.0.0x
         uses: actions/setup-node@v3
         with:
-          node-version: 18.0.0
+          node-version: 24
       - name: Run pa11y
         run: |
           npm install -g pa11y@latest
@@ -209,7 +209,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 24
           cache: 'npm'
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 24
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 24
 
       # 3. Install dependencies and build
       - name: Install dependencies


### PR DESCRIPTION
## What

Clears the Kodiak **high-risk end-of-life Node.js** finding (flagged file: `.github/workflows/manual-build-release.yml`).

Bumps every `actions/setup-node` `node-version` to **24** (current LTS) across all GitHub Actions workflows. Node 14/16/18 are all EOL; per the Kodiak guidance, 22 (EOL April 2027) is skipped in favor of 24.

## Files changed (node-version only, 18 lines)

- `manual-build-release.yml` (the flagged file)
- `release-assets.yml`
- `point-release.yml`
- `static.yml`
- `merge.yaml`
- `pull-request.yaml`
- `bulk-publisher-e2e-scheduled.yml`

## Notes

- `package.json` `engines` still declares `>=16.0.0 <19.0.0`. Left as-is to keep this PR workflow-only. There is no `engine-strict`, so `npm ci` on Node 24 will at most emit `EBADENGINE` warnings, not fail. Watching CI to confirm `npm ci` / `npm run build` pass on 24; if a dependency won't build on 24, a follow-up will address `engines` + any dep bumps.
- Kodiak config: `.kodiak/config.yaml` on `main`.
