### PR TITLE
feat(mwpw-184989): add agent-driven visual + perceptual QA review on PRs

### DIFF
--- a/.github/qa/agent-review.mjs
+++ b/.github/qa/agent-review.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * Agent QA review (advisory).
+ *
+ * Builds-aware, perceptual review of a PR's CaaS build on the REAL
+ * business.adobe.com collection page. Pipeline:
+ *   inject the PR's local dist into the live page via CDP request interception
+ *   -> screenshot PR build vs current stable -> pixel diff
+ *   -> hand (PR screenshot, stable screenshot, diff image, PR code diff, PR
+ *      title+description) to a Claude judge via the Adobe LLM proxy
+ *   -> post the findings as a PR comment.
+ *
+ * Non-gating: this only ever comments. The deterministic gates (unit / WDIO
+ * e2e / pa11y) live elsewhere. The agent's job here is judgment + exploration
+ * on the real page, which can't be a deterministic on/off check.
+ *
+ * Required env:
+ *   PR_NUMBER         PR to review
+ *   IMS_ACCESS_TOKEN  bearer for the LLM proxy (repo secret)
+ *   PROXY_URL         LLM proxy /v1/messages endpoint (LLM_PROXY_ENDPOINT secret)
+ *   GH_TOKEN          token for `gh pr comment`
+ * Optional env:
+ *   GH_REPO (default adobecom/caas), DIST_DIR (default ../../dist),
+ *   CDP_URL (default http://127.0.0.1:9222), BASE_URL, CAASVER (default 0.53.0),
+ *   MODEL (default claude-sonnet-4-6), OUT_DIR (default ./agent-review-out),
+ *   RUN_URL (link back to the workflow run, for the comment).
+ */
+import { chromium } from 'playwright';
+import pixelmatch from 'pixelmatch';
+import { PNG } from 'pngjs';
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+
+const env = (k, d) => process.env[k] ?? d;
+const PR = env('PR_NUMBER');
+const REPO = env('GH_REPO', 'adobecom/caas');
+const DIST = env('DIST_DIR', '../../dist');
+const CDP = env('CDP_URL', 'http://127.0.0.1:9222');
+const BASE = env('BASE_URL', 'https://business.adobe.com/resources/main.html');
+const CAASVER = env('CAASVER', '0.53.0');
+const TOKEN = env('IMS_ACCESS_TOKEN');
+const PROXY = env('PROXY_URL');
+const MODEL = env('MODEL', 'claude-sonnet-4-6');
+const OUT = env('OUT_DIR', 'agent-review-out');
+const RUN_URL = env('RUN_URL', '');
+
+if (!PR || !TOKEN || !PROXY) {
+  console.error('Missing required env: PR_NUMBER, IMS_ACCESS_TOKEN, PROXY_URL');
+  process.exit(1);
+}
+mkdirSync(OUT, { recursive: true });
+const sh = (c) => execSync(c, { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
+const ct = (f) => (f.endsWith('.css') ? 'text/css' : 'application/javascript');
+const b64 = (p) => readFileSync(p).toString('base64');
+
+// 1) PR context: intent (title/body) + what changed (files/diff)
+const meta = JSON.parse(sh(`gh pr view ${PR} -R ${REPO} --json title,body,files`));
+let codeDiff = '';
+try { codeDiff = sh(`gh pr diff ${PR} -R ${REPO}`); } catch { /* diff optional */ }
+codeDiff = codeDiff.slice(0, 12000);
+const changedFiles = (meta.files || []).map((f) => f.path).join('\n').slice(0, 1500);
+
+// 2) screenshots: PR build injected vs current stable, on the same real page
+const url = `${BASE}?caasver=${CAASVER}`;
+const browser = await chromium.connectOverCDP(CDP);
+const ctx = browser.contexts()[0] || (await browser.newContext());
+async function shot(injectPrBuild, outFile) {
+  const page = await ctx.newPage();
+  await page.setViewportSize({ width: 1280, height: 1800 });
+  if (injectPrBuild) {
+    await page.route('**/caas-libs/**', async (route) => {
+      const file = route.request().url().split('?')[0].split('/').pop();
+      try { await route.fulfill({ path: `${DIST}/${file}`, contentType: ct(file) }); }
+      catch { await route.continue(); }
+    });
+  }
+  await page.goto(url, { waitUntil: 'load', timeout: 45000 }).catch(() => {});
+  await page.waitForTimeout(15000); // CaaS grid loads async from the collection API
+  const card = await page.$('.consonant-Card');
+  if (card) await card.scrollIntoViewIfNeeded().catch(() => {});
+  await page.waitForTimeout(1500);
+  await page.screenshot({ path: outFile });
+  await page.close();
+}
+await shot(true, `${OUT}/pr.png`);
+await shot(false, `${OUT}/stable.png`);
+await browser.close();
+
+// 3) pixel diff (the deterministic clue we hand the agent)
+const a = PNG.sync.read(readFileSync(`${OUT}/pr.png`));
+const b = PNG.sync.read(readFileSync(`${OUT}/stable.png`));
+const w = Math.min(a.width, b.width), h = Math.min(a.height, b.height);
+const diff = new PNG({ width: w, height: h });
+const changed = pixelmatch(a.data, b.data, diff.data, w, h, { threshold: 0.12, includeAA: false });
+writeFileSync(`${OUT}/diff.png`, PNG.sync.write(diff));
+const pct = (100 * changed / (w * h)).toFixed(2);
+
+// 4) Claude judge (multimodal) via the Adobe LLM proxy
+const prompt = [
+  'You are doing visual + perceptual QA on a pull request to the Adobe CaaS card collection,',
+  'rendered on the REAL business.adobe.com page.',
+  '',
+  `PR title: ${meta.title}`,
+  `PR description:\n${(meta.body || '(none)').slice(0, 2000)}`,
+  `Changed files:\n${changedFiles}`,
+  '',
+  'Code diff (truncated):',
+  codeDiff || '(unavailable)',
+  '',
+  `You are given three images: (1) the page with THIS PR's build injected, (2) the current stable build, (3) a pixel-diff highlighting changes. ${pct}% of pixels differ.`,
+  'Use the diff and code diff as clues — note that some diff is just different cards loading (content noise), which you should ignore; focus on layout/styling/readability/a11y.',
+  'Report ONLY things that look off, broken, or regressed (truncated text, broken layout, bad contrast, missing/overlapping cards, unintended styling), and tie each to the change when you can.',
+  'If nothing looks wrong, say so in one line. Be concise and specific.',
+].join('\n');
+
+const payload = {
+  model: MODEL,
+  max_tokens: 1200,
+  messages: [{
+    role: 'user',
+    content: [
+      { type: 'text', text: prompt },
+      { type: 'text', text: 'Image 1 — PR build:' },
+      { type: 'image', source: { type: 'base64', media_type: 'image/png', data: b64(`${OUT}/pr.png`) } },
+      { type: 'text', text: 'Image 2 — stable build:' },
+      { type: 'image', source: { type: 'base64', media_type: 'image/png', data: b64(`${OUT}/stable.png`) } },
+      { type: 'text', text: 'Image 3 — pixel diff (changes highlighted):' },
+      { type: 'image', source: { type: 'base64', media_type: 'image/png', data: b64(`${OUT}/diff.png`) } },
+    ],
+  }],
+};
+let findings = '(agent judge unavailable)';
+try {
+  const res = await fetch(PROXY, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${TOKEN}`, 'Content-Type': 'application/json', 'anthropic-version': '2023-06-01' },
+    body: JSON.stringify(payload),
+  });
+  if (res.ok) { const data = await res.json(); findings = data?.content?.[0]?.text || findings; }
+  else { findings = `(agent judge unavailable: HTTP ${res.status})`; }
+} catch (e) { findings = `(agent judge error: ${String(e).slice(0, 200)})`; }
+
+// 5) post advisory PR comment
+const comment = [
+  '## 🤖 Agent QA review — visual + perceptual (advisory, non-blocking)',
+  '',
+  `Reviewed this PR's build on the live business.adobe.com collection page. **${pct}%** of pixels changed vs the stable build.`,
+  '',
+  findings,
+  '',
+  RUN_URL ? `_Screenshots and the pixel diff are in the [workflow artifacts](${RUN_URL})._` : '',
+].join('\n');
+writeFileSync(`${OUT}/comment.md`, comment);
+sh(`gh pr comment ${PR} -R ${REPO} --body-file ${OUT}/comment.md`);
+console.log(`agent-review: posted comment on PR #${PR} (pct changed ${pct})`);
+process.exit(0);

--- a/.github/qa/agent-review.mjs
+++ b/.github/qa/agent-review.mjs
@@ -1,178 +1,75 @@
 #!/usr/bin/env node
-/**
- * Agent QA review (advisory, non-gating).
- *
- * Builds-aware perceptual review of a PR's CaaS build on the REAL
- * business.adobe.com collection page:
- *   inject the PR's local dist into the live page via CDP request interception
- *   -> screenshot PR build vs current stable -> pixel diff
- *   -> hand (PR screenshot, stable screenshot, diff image, PR code diff, PR
- *      title+description) to a Claude judge via the Adobe LLM proxy
- *   -> create-or-update a single PR comment. Only ever comments.
- *
- * Required env: PR_NUMBER, IMS_ACCESS_TOKEN, PROXY_URL, GH_TOKEN
- * Optional: GH_REPO, DIST_DIR, CDP_URL, BASE_URL, CAASVER, MODEL, OUT_DIR, RUN_URL
- */
-import { chromium } from 'playwright';
-import pixelmatch from 'pixelmatch';
-import { PNG } from 'pngjs';
-import { execFileSync } from 'node:child_process';
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { isAbsolute, resolve } from 'node:path';
+/** Interactive agent QA review (advisory, non-blocking).
+ *  Drives qa-runner-v2.mjs (the interactive tool-use agent) against the PR
+ *  build injected on the live business.adobe.com page, then posts findings as
+ *  a single PR comment. Never gates. */
+import { execFileSync, spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from 'node:fs';
 
 const env = (k, d) => process.env[k] ?? d;
 const PR = env('PR_NUMBER');
 const REPO = env('GH_REPO', 'adobecom/caas');
-const DIST = env('DIST_DIR', '../../dist');
-const CDP = env('CDP_URL', 'http://127.0.0.1:9222');
+const DIST = env('DIST_DIR');
 const BASE = env('BASE_URL', 'https://business.adobe.com/resources/main.html');
 const CAASVER = env('CAASVER', '0.53.0');
-const TOKEN = env('IMS_ACCESS_TOKEN');
-const PROXY = env('PROXY_URL');
-const MODEL = env('MODEL', 'claude-sonnet-4-6');
-const OUT = env('OUT_DIR', 'agent-review-out');
 const RUN_URL = env('RUN_URL', '');
-
-// Strict validation — these flow into subprocess calls / the filesystem / the network.
 if (!/^\d+$/.test(PR || '')) { console.error('PR_NUMBER must be a positive integer'); process.exit(1); }
-if (!/^[\w.-]+\/[\w.-]+$/.test(REPO)) { console.error('GH_REPO must be owner/repo'); process.exit(1); }
-if (!TOKEN || !PROXY) { console.error('Missing IMS_ACCESS_TOKEN / PROXY_URL'); process.exit(1); }
-if (!PROXY.startsWith('https://')) { console.error('PROXY_URL must be an https URL'); process.exit(1); }
-if (isAbsolute(OUT) || OUT.includes('..')) { console.error('OUT_DIR must be a relative path'); process.exit(1); }
-mkdirSync(OUT, { recursive: true });
 
-// Only ever serve these exact bundle files, resolved strictly inside the dist dir.
-const ALLOWED = new Set(['main.min.js', 'app.css', 'react.umd.js', 'react.dom.umd.js']);
-const DIST_ROOT = resolve(DIST);
-
-// No shell: execFileSync with an explicit args array (no injection surface).
 const gh = (args) => execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
-const ct = (f) => (f.endsWith('.css') ? 'text/css' : 'application/javascript');
-const b64 = (p) => readFileSync(p).toString('base64');
-// Strip token-shaped strings before sending PR text to the external proxy.
-const redact = (s) => (s || '').replace(
-  /\b(gh[pousr]_[A-Za-z0-9]{20,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}|AKIA[0-9A-Z]{16})\b/g,
-  '[REDACTED]',
-);
+const redact = (s) => (s || '').replace(/\b(gh[pousr]_[A-Za-z0-9]{20,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}|AKIA[0-9A-Z]{16})\b/g, '[REDACTED]');
 
-// 1) PR context — redact BEFORE truncating so a token can't be split past the regex.
 const meta = JSON.parse(gh(['pr', 'view', PR, '-R', REPO, '--json', 'title,body,files']));
-let codeDiff = '';
-try { codeDiff = gh(['pr', 'diff', PR, '-R', REPO]); } catch { /* optional */ }
-codeDiff = redact(codeDiff).slice(0, 12000);
-const changedFiles = (meta.files || []).map((f) => f.path).join('\n').slice(0, 1500);
+let diff = '';
+try { diff = gh(['pr', 'diff', PR, '-R', REPO]); } catch {}
 
-// 2) screenshots: PR build injected vs current stable, on the same real page
-const url = `${BASE}?caasver=${CAASVER}`;
-const browser = await chromium.connectOverCDP(CDP);
-const ctx = browser.contexts()[0] || (await browser.newContext());
-async function shot(injectPrBuild, outFile) {
-  const page = await ctx.newPage();
-  await page.setViewportSize({ width: 1280, height: 1800 });
-  if (injectPrBuild) {
-    await page.route('**/caas-libs/**', async (route) => {
-      const file = route.request().url().split('?')[0].split('/').pop();
-      const full = resolve(DIST_ROOT, file);
-      if (!ALLOWED.has(file) || !full.startsWith(DIST_ROOT + '/')) return route.continue();
-      try { await route.fulfill({ path: full, contentType: ct(file) }); }
-      catch { await route.continue(); }
-    });
-  }
-  await page.goto(url, { waitUntil: 'load', timeout: 45000 }).catch(() => {});
-  await page.waitForTimeout(15000); // CaaS grid loads async from the collection API
-  const card = await page.$('.consonant-Card');
-  if (card) await card.scrollIntoViewIfNeeded().catch(() => {});
-  await page.waitForTimeout(1500);
-  await page.screenshot({ path: outFile });
-  await page.close();
-}
-await shot(true, `${OUT}/pr.png`);
-await shot(false, `${OUT}/stable.png`);
-await browser.close();
-
-// 3) pixel diff — crop both to the common rectangle so buffers match exactly
-const a = PNG.sync.read(readFileSync(`${OUT}/pr.png`));
-const b = PNG.sync.read(readFileSync(`${OUT}/stable.png`));
-const w = Math.min(a.width, b.width), h = Math.min(a.height, b.height);
-const ca = new PNG({ width: w, height: h }); PNG.bitblt(a, ca, 0, 0, w, h, 0, 0);
-const cb = new PNG({ width: w, height: h }); PNG.bitblt(b, cb, 0, 0, w, h, 0, 0);
-const diff = new PNG({ width: w, height: h });
-const changed = pixelmatch(ca.data, cb.data, diff.data, w, h, { threshold: 0.12, includeAA: false });
-writeFileSync(`${OUT}/diff.png`, PNG.sync.write(diff));
-const pct = (100 * changed / (w * h)).toFixed(2);
-
-// 4) Claude judge (multimodal) via the Adobe LLM proxy
-const prompt = [
-  'You are doing visual + perceptual QA on a pull request to the Adobe CaaS card collection,',
-  'rendered on the REAL business.adobe.com page.',
+const instruction = [
+  `Target URL: ${BASE}?caasver=${CAASVER}`,
   '',
+  `You are QA-reviewing pull request #${PR}. The PR's CaaS build is already injected into this live page, so you are testing the PR's code on the real business.adobe.com collection.`,
   `PR title: ${meta.title}`,
-  `PR description:\n${redact(meta.body || '(none)').slice(0, 2000)}`,
-  `Changed files:\n${changedFiles}`,
+  `PR description: ${redact(meta.body || '(none)').slice(0, 1500)}`,
+  `Changed files: ${(meta.files || []).map((f) => f.path).join(', ').slice(0, 800)}`,
+  `Code diff (truncated, secrets redacted): ${redact(diff).slice(0, 6000)}`,
   '',
-  'Code diff (truncated, secrets redacted):',
-  codeDiff || '(unavailable)',
-  '',
-  `You are given three images: (1) the page with THIS PR's build injected, (2) the current stable build, (3) a pixel-diff highlighting changes. ${pct}% of pixels differ.`,
-  'Some diff is just different cards loading (content noise) — ignore that; focus on layout/styling/readability/a11y.',
-  'Report ONLY things that look off, broken, or regressed, and tie each to the change when you can.',
-  'If nothing looks wrong, say so in one line. Be concise and specific.',
+  'Interact like a real user: load the collection, apply a filter, run a search, paginate, and open/inspect a few cards. Screenshot after each action and actually look. Run run_axe and get_console_errors at least once. Focus on what this PR could have affected. Report anything broken, truncated, misaligned, low-contrast, or behaving incorrectly; if nothing is wrong, say so. End with done(report, verdict).',
 ].join('\n');
 
-const payload = {
-  model: MODEL,
-  max_tokens: 1200,
-  messages: [{
-    role: 'user',
-    content: [
-      { type: 'text', text: prompt },
-      { type: 'text', text: 'Image 1 — PR build:' },
-      { type: 'image', source: { type: 'base64', media_type: 'image/png', data: b64(`${OUT}/pr.png`) } },
-      { type: 'text', text: 'Image 2 — stable build:' },
-      { type: 'image', source: { type: 'base64', media_type: 'image/png', data: b64(`${OUT}/stable.png`) } },
-      { type: 'text', text: 'Image 3 — pixel diff (changes highlighted):' },
-      { type: 'image', source: { type: 'base64', media_type: 'image/png', data: b64(`${OUT}/diff.png`) } },
-    ],
-  }],
-};
-let findings = '(agent judge unavailable)';
-try {
-  const res = await fetch(PROXY, {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${TOKEN}`, 'Content-Type': 'application/json', 'anthropic-version': '2023-06-01' },
-    body: JSON.stringify(payload),
-  });
-  if (res.ok) { const data = await res.json(); findings = data?.content?.[0]?.text || findings; }
-  else { findings = `(agent judge unavailable: HTTP ${res.status})`; }
-} catch (e) { findings = `(agent judge error: ${String(e).slice(0, 200)})`; }
+const REPORT_OUT = '/tmp/pr-review-report.json';
+try { unlinkSync(REPORT_OUT); } catch {}
+spawnSync('node', ['qa-runner-v2.mjs', instruction], {
+  stdio: 'inherit',
+  env: { ...process.env, DIST_DIR: DIST || '', REPORT_OUT, MAX_TURNS: env('MAX_TURNS', '14') },
+});
 
-// 5) create-or-update a SINGLE comment (found by a hidden marker) so re-runs don't spam,
-//    and so we never clobber another bot's comment.
+let verdict = 'UNKNOWN', report = '(agent produced no report)';
+if (existsSync(REPORT_OUT)) {
+  try { const j = JSON.parse(readFileSync(REPORT_OUT, 'utf8')); verdict = j.verdict || verdict; report = j.report || report; } catch {}
+}
+
 const MARKER = '<!-- agent-qa-review -->';
 const comment = [
   MARKER,
-  '## 🤖 Agent QA review — visual + perceptual (advisory, non-blocking)',
+  '## 🤖 Agent QA review — interactive (advisory, non-blocking)',
   '',
-  `Reviewed this PR's build on the live business.adobe.com collection page. **${pct}%** of pixels changed vs the stable build.`,
+  `The agent drove the PR build on the live business.adobe.com collection page — filtering, searching, paginating, inspecting cards. Verdict: **${verdict}**.`,
   '',
-  findings,
+  report,
   '',
-  RUN_URL ? `_Screenshots and the pixel diff are in the [workflow artifacts](${RUN_URL})._` : '',
+  RUN_URL ? `_Screenshots / console / axe artifacts are in the [workflow run](${RUN_URL})._` : '',
 ].join('\n');
 
-let existingId = '';
+let id = '';
 try {
   const list = JSON.parse(gh(['pr', 'view', PR, '-R', REPO, '--json', 'comments']));
   const mine = (list.comments || []).filter((c) => (c.body || '').includes(MARKER)).pop();
-  if (mine && mine.url) existingId = mine.url.split('issuecomment-').pop();
-} catch { /* fall through to create */ }
-
-if (existingId) {
-  gh(['api', '-X', 'PATCH', `repos/${REPO}/issues/comments/${existingId}`, '-f', `body=${comment}`]);
-  console.log(`agent-review: updated comment ${existingId} on PR #${PR} (pct ${pct})`);
+  if (mine && mine.url) id = mine.url.split('issuecomment-').pop();
+} catch {}
+if (id) {
+  gh(['api', '-X', 'PATCH', `repos/${REPO}/issues/comments/${id}`, '-f', `body=${comment}`]);
 } else {
-  writeFileSync(`${OUT}/comment.md`, comment);
-  gh(['pr', 'comment', PR, '-R', REPO, '--body-file', `${OUT}/comment.md`]);
-  console.log(`agent-review: posted comment on PR #${PR} (pct ${pct})`);
+  mkdirSync('agent-review-out', { recursive: true });
+  writeFileSync('agent-review-out/comment.md', comment);
+  gh(['pr', 'comment', PR, '-R', REPO, '--body-file', 'agent-review-out/comment.md']);
 }
+console.log(`agent-review: posted interactive review on PR #${PR} (verdict ${verdict})`);
 process.exit(0);

--- a/.github/qa/agent-review.mjs
+++ b/.github/qa/agent-review.mjs
@@ -1,44 +1,94 @@
 #!/usr/bin/env node
 /** Interactive agent QA review (advisory, non-blocking).
- *  Drives qa-runner-v2.mjs (the interactive tool-use agent) against the PR
- *  build injected on the live business.adobe.com page, then posts findings as
- *  a single PR comment. Never gates. */
+ *  1) Capture a PR-build-vs-stable visual diff on the live page (the guide).
+ *  2) Drive the interactive qa-runner on the PR build, handing it the diff
+ *     image + the PR code diff as context.
+ *  3) Post a single deduped PR comment. Never gates. */
 import { execFileSync, spawnSync } from 'node:child_process';
 import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { chromium } from 'playwright';
+import pixelmatch from 'pixelmatch';
+import { PNG } from 'pngjs';
 
 const env = (k, d) => process.env[k] ?? d;
 const PR = env('PR_NUMBER');
 const REPO = env('GH_REPO', 'adobecom/caas');
 const DIST = env('DIST_DIR');
+const CDP = env('CDP_URL', 'http://127.0.0.1:9222');
 const BASE = env('BASE_URL', 'https://business.adobe.com/resources/main.html');
 const CAASVER = env('CAASVER', '0.53.0');
 const RUN_URL = env('RUN_URL', '');
+const OUT = resolve(env('OUT_DIR', 'agent-review-out'));
 if (!/^\d+$/.test(PR || '')) { console.error('PR_NUMBER must be a positive integer'); process.exit(1); }
+if (!DIST) { console.error('DIST_DIR required'); process.exit(1); }
+mkdirSync(OUT, { recursive: true });
 
 const gh = (args) => execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
 const redact = (s) => (s || '').replace(/\b(gh[pousr]_[A-Za-z0-9]{20,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}|AKIA[0-9A-Z]{16})\b/g, '[REDACTED]');
+const ALLOW = new Set(['main.min.js', 'app.css', 'react.umd.js', 'react.dom.umd.js']);
+const ct = (f) => (f.endsWith('.css') ? 'text/css' : 'application/javascript');
 
+// PR context
 const meta = JSON.parse(gh(['pr', 'view', PR, '-R', REPO, '--json', 'title,body,files']));
 let diff = '';
 try { diff = gh(['pr', 'diff', PR, '-R', REPO]); } catch {}
 
+// 1) capture PR-vs-stable visual diff (the guide)
+const url = `${BASE}?caasver=${CAASVER}`;
+let pct = 'n/a';
+try {
+  const browser = await chromium.connectOverCDP(CDP);
+  const c = browser.contexts()[0] || (await browser.newContext());
+  const shot = async (inject, out) => {
+    const p = await c.newPage();
+    await p.setViewportSize({ width: 1280, height: 1800 });
+    if (inject) {
+      await p.route('**/caas-libs/**', async (r) => {
+        const f = r.request().url().split('?')[0].split('/').pop();
+        if (!ALLOW.has(f)) return r.continue();
+        try { await r.fulfill({ path: `${DIST}/${f}`, contentType: ct(f) }); } catch { await r.continue(); }
+      });
+    }
+    await p.goto(url, { waitUntil: 'load', timeout: 45000 }).catch(() => {});
+    await p.waitForTimeout(15000);
+    const card = await p.$('.consonant-Card');
+    if (card) await card.scrollIntoViewIfNeeded().catch(() => {});
+    await p.waitForTimeout(1500);
+    await p.screenshot({ path: out });
+    await p.close();
+  };
+  await shot(true, `${OUT}/pr.png`);
+  await shot(false, `${OUT}/stable.png`);
+  const a = PNG.sync.read(readFileSync(`${OUT}/pr.png`)), b = PNG.sync.read(readFileSync(`${OUT}/stable.png`));
+  const w = Math.min(a.width, b.width), h = Math.min(a.height, b.height);
+  const ca = new PNG({ width: w, height: h }); PNG.bitblt(a, ca, 0, 0, w, h, 0, 0);
+  const cb = new PNG({ width: w, height: h }); PNG.bitblt(b, cb, 0, 0, w, h, 0, 0);
+  const d = new PNG({ width: w, height: h });
+  const n = pixelmatch(ca.data, cb.data, d.data, w, h, { threshold: 0.12, includeAA: false });
+  writeFileSync(`${OUT}/diff.png`, PNG.sync.write(d));
+  pct = (100 * n / (w * h)).toFixed(2);
+} catch (e) { console.log('visual-diff capture failed: ' + String(e).slice(0, 160)); }
+
+// 2) interactive agent, guided by the diff + the PR code diff
 const instruction = [
-  `Target URL: ${BASE}?caasver=${CAASVER}`,
+  `Target URL: ${url}`,
   '',
   `You are QA-reviewing pull request #${PR}. The PR's CaaS build is already injected into this live page, so you are testing the PR's code on the real business.adobe.com collection.`,
+  `A visual diff of the PR build vs the current stable build has been captured; ${pct}% of pixels changed. FIRST call load_screenshots(["${OUT}/diff.png","${OUT}/pr.png","${OUT}/stable.png"]) to SEE what changed, then go interact with the areas that changed.`,
   `PR title: ${meta.title}`,
   `PR description: ${redact(meta.body || '(none)').slice(0, 1500)}`,
   `Changed files: ${(meta.files || []).map((f) => f.path).join(', ').slice(0, 800)}`,
   `Code diff (truncated, secrets redacted): ${redact(diff).slice(0, 6000)}`,
   '',
-  'Interact like a real user: load the collection, apply a filter, run a search, paginate, and open/inspect a few cards. Screenshot after each action and actually look. Run run_axe and get_console_errors at least once. Focus on what this PR could have affected. Report anything broken, truncated, misaligned, low-contrast, or behaving incorrectly; if nothing is wrong, say so. End with done(report, verdict).',
+  'Then interact like a real user: apply a filter, run a search, paginate, open/inspect cards. Use the visual diff + code diff to focus where this PR changed things, and judge whether each change is intended or a regression. Run run_axe and get_console_errors at least once. Report anything broken/truncated/misaligned/low-contrast/wrong; if clean, say so. End with done(report, verdict).',
 ].join('\n');
 
 const REPORT_OUT = '/tmp/pr-review-report.json';
 try { unlinkSync(REPORT_OUT); } catch {}
 spawnSync('node', ['qa-runner-v2.mjs', instruction], {
   stdio: 'inherit',
-  env: { ...process.env, DIST_DIR: DIST || '', REPORT_OUT, MAX_TURNS: env('MAX_TURNS', '14') },
+  env: { ...process.env, DIST_DIR: DIST, REPORT_OUT, MAX_TURNS: env('MAX_TURNS', '16') },
 });
 
 let verdict = 'UNKNOWN', report = '(agent produced no report)';
@@ -49,27 +99,26 @@ if (existsSync(REPORT_OUT)) {
 const MARKER = '<!-- agent-qa-review -->';
 const comment = [
   MARKER,
-  '## 🤖 Agent QA review — interactive (advisory, non-blocking)',
+  '## 🤖 Agent QA review — interactive + visual diff (advisory, non-blocking)',
   '',
-  `The agent drove the PR build on the live business.adobe.com collection page — filtering, searching, paginating, inspecting cards. Verdict: **${verdict}**.`,
+  `Drove the PR build on the live business.adobe.com collection (filtered, searched, paginated, inspected cards), guided by a PR-vs-stable visual diff (**${pct}%** of pixels changed) and the PR code diff. Verdict: **${verdict}**.`,
   '',
   report,
   '',
-  RUN_URL ? `_Screenshots / console / axe artifacts are in the [workflow run](${RUN_URL})._` : '',
+  RUN_URL ? `_PR / stable / diff screenshots + console + axe artifacts in the [workflow run](${RUN_URL})._` : '',
 ].join('\n');
 
 let id = '';
 try {
   const list = JSON.parse(gh(['pr', 'view', PR, '-R', REPO, '--json', 'comments']));
-  const mine = (list.comments || []).filter((c) => (c.body || '').includes(MARKER)).pop();
+  const mine = (list.comments || []).filter((cm) => (cm.body || '').includes(MARKER)).pop();
   if (mine && mine.url) id = mine.url.split('issuecomment-').pop();
 } catch {}
 if (id) {
   gh(['api', '-X', 'PATCH', `repos/${REPO}/issues/comments/${id}`, '-f', `body=${comment}`]);
 } else {
-  mkdirSync('agent-review-out', { recursive: true });
-  writeFileSync('agent-review-out/comment.md', comment);
-  gh(['pr', 'comment', PR, '-R', REPO, '--body-file', 'agent-review-out/comment.md']);
+  writeFileSync(`${OUT}/comment.md`, comment);
+  gh(['pr', 'comment', PR, '-R', REPO, '--body-file', `${OUT}/comment.md`]);
 }
-console.log(`agent-review: posted interactive review on PR #${PR} (verdict ${verdict})`);
+console.log(`agent-review: interactive+diff review posted on PR #${PR} (verdict ${verdict}, diff ${pct}%)`);
 process.exit(0);

--- a/.github/qa/agent-review.mjs
+++ b/.github/qa/agent-review.mjs
@@ -8,7 +8,7 @@
  *   -> screenshot PR build vs current stable -> pixel diff
  *   -> hand (PR screenshot, stable screenshot, diff image, PR code diff, PR
  *      title+description) to a Claude judge via the Adobe LLM proxy
- *   -> post the findings as a PR comment. Only ever comments.
+ *   -> create-or-update a single PR comment. Only ever comments.
  *
  * Required env: PR_NUMBER, IMS_ACCESS_TOKEN, PROXY_URL, GH_TOKEN
  * Optional: GH_REPO, DIST_DIR, CDP_URL, BASE_URL, CAASVER, MODEL, OUT_DIR, RUN_URL
@@ -18,6 +18,7 @@ import pixelmatch from 'pixelmatch';
 import { PNG } from 'pngjs';
 import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { isAbsolute, resolve } from 'node:path';
 
 const env = (k, d) => process.env[k] ?? d;
 const PR = env('PR_NUMBER');
@@ -32,11 +33,17 @@ const MODEL = env('MODEL', 'claude-sonnet-4-6');
 const OUT = env('OUT_DIR', 'agent-review-out');
 const RUN_URL = env('RUN_URL', '');
 
-// Strict validation — these flow into subprocess calls.
+// Strict validation — these flow into subprocess calls / the filesystem / the network.
 if (!/^\d+$/.test(PR || '')) { console.error('PR_NUMBER must be a positive integer'); process.exit(1); }
 if (!/^[\w.-]+\/[\w.-]+$/.test(REPO)) { console.error('GH_REPO must be owner/repo'); process.exit(1); }
 if (!TOKEN || !PROXY) { console.error('Missing IMS_ACCESS_TOKEN / PROXY_URL'); process.exit(1); }
+if (!PROXY.startsWith('https://')) { console.error('PROXY_URL must be an https URL'); process.exit(1); }
+if (isAbsolute(OUT) || OUT.includes('..')) { console.error('OUT_DIR must be a relative path'); process.exit(1); }
 mkdirSync(OUT, { recursive: true });
+
+// Only ever serve these exact bundle files, resolved strictly inside the dist dir.
+const ALLOWED = new Set(['main.min.js', 'app.css', 'react.umd.js', 'react.dom.umd.js']);
+const DIST_ROOT = resolve(DIST);
 
 // No shell: execFileSync with an explicit args array (no injection surface).
 const gh = (args) => execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
@@ -48,11 +55,11 @@ const redact = (s) => (s || '').replace(
   '[REDACTED]',
 );
 
-// 1) PR context
+// 1) PR context — redact BEFORE truncating so a token can't be split past the regex.
 const meta = JSON.parse(gh(['pr', 'view', PR, '-R', REPO, '--json', 'title,body,files']));
 let codeDiff = '';
 try { codeDiff = gh(['pr', 'diff', PR, '-R', REPO]); } catch { /* optional */ }
-codeDiff = redact(codeDiff.slice(0, 12000));
+codeDiff = redact(codeDiff).slice(0, 12000);
 const changedFiles = (meta.files || []).map((f) => f.path).join('\n').slice(0, 1500);
 
 // 2) screenshots: PR build injected vs current stable, on the same real page
@@ -65,7 +72,9 @@ async function shot(injectPrBuild, outFile) {
   if (injectPrBuild) {
     await page.route('**/caas-libs/**', async (route) => {
       const file = route.request().url().split('?')[0].split('/').pop();
-      try { await route.fulfill({ path: `${DIST}/${file}`, contentType: ct(file) }); }
+      const full = resolve(DIST_ROOT, file);
+      if (!ALLOWED.has(file) || !full.startsWith(DIST_ROOT + '/')) return route.continue();
+      try { await route.fulfill({ path: full, contentType: ct(file) }); }
       catch { await route.continue(); }
     });
   }
@@ -137,8 +146,11 @@ try {
   else { findings = `(agent judge unavailable: HTTP ${res.status})`; }
 } catch (e) { findings = `(agent judge error: ${String(e).slice(0, 200)})`; }
 
-// 5) post advisory PR comment (no shell)
+// 5) create-or-update a SINGLE comment (found by a hidden marker) so re-runs don't spam,
+//    and so we never clobber another bot's comment.
+const MARKER = '<!-- agent-qa-review -->';
 const comment = [
+  MARKER,
   '## 🤖 Agent QA review — visual + perceptual (advisory, non-blocking)',
   '',
   `Reviewed this PR's build on the live business.adobe.com collection page. **${pct}%** of pixels changed vs the stable build.`,
@@ -147,7 +159,20 @@ const comment = [
   '',
   RUN_URL ? `_Screenshots and the pixel diff are in the [workflow artifacts](${RUN_URL})._` : '',
 ].join('\n');
-writeFileSync(`${OUT}/comment.md`, comment);
-gh(['pr', 'comment', PR, '-R', REPO, '--body-file', `${OUT}/comment.md`]);
-console.log(`agent-review: posted comment on PR #${PR} (pct changed ${pct})`);
+
+let existingId = '';
+try {
+  const list = JSON.parse(gh(['pr', 'view', PR, '-R', REPO, '--json', 'comments']));
+  const mine = (list.comments || []).filter((c) => (c.body || '').includes(MARKER)).pop();
+  if (mine && mine.url) existingId = mine.url.split('issuecomment-').pop();
+} catch { /* fall through to create */ }
+
+if (existingId) {
+  gh(['api', '-X', 'PATCH', `repos/${REPO}/issues/comments/${existingId}`, '-f', `body=${comment}`]);
+  console.log(`agent-review: updated comment ${existingId} on PR #${PR} (pct ${pct})`);
+} else {
+  writeFileSync(`${OUT}/comment.md`, comment);
+  gh(['pr', 'comment', PR, '-R', REPO, '--body-file', `${OUT}/comment.md`]);
+  console.log(`agent-review: posted comment on PR #${PR} (pct ${pct})`);
+}
 process.exit(0);

--- a/.github/qa/agent-review.mjs
+++ b/.github/qa/agent-review.mjs
@@ -60,6 +60,10 @@ try {
   };
   await shot(true, `${OUT}/pr.png`);
   await shot(false, `${OUT}/stable.png`);
+  // Disconnect THIS CDP client (does not kill the persistent Chrome) so the
+  // qa-runner subprocess is the sole Playwright client — two concurrent clients
+  // on one browser cause navigation timeouts and hangs.
+  await browser.close();
   const a = PNG.sync.read(readFileSync(`${OUT}/pr.png`)), b = PNG.sync.read(readFileSync(`${OUT}/stable.png`));
   const w = Math.min(a.width, b.width), h = Math.min(a.height, b.height);
   const ca = new PNG({ width: w, height: h }); PNG.bitblt(a, ca, 0, 0, w, h, 0, 0);
@@ -75,7 +79,7 @@ const instruction = [
   `Target URL: ${url}`,
   '',
   `You are QA-reviewing pull request #${PR}. The PR's CaaS build is already injected into this live page, so you are testing the PR's code on the real business.adobe.com collection.`,
-  `A visual diff of the PR build vs the current stable build has been captured; ${pct}% of pixels changed. FIRST call load_screenshots(["${OUT}/diff.png","${OUT}/pr.png","${OUT}/stable.png"]) to SEE what changed, then go interact with the areas that changed.`,
+  `A pixel diff of the PR build vs the current stable build was captured; ${pct}% of pixels changed. Magenta/colored regions in the diff mark where the PR changed the rendering. Call load_screenshots(["${OUT}/diff.png"]) ONCE to see those regions, then go interact with the areas that changed. (Do NOT load pr.png/stable.png — the diff alone is your guide.)`,
   `PR title: ${meta.title}`,
   `PR description: ${redact(meta.body || '(none)').slice(0, 1500)}`,
   `Changed files: ${(meta.files || []).map((f) => f.path).join(', ').slice(0, 800)}`,
@@ -86,12 +90,18 @@ const instruction = [
 
 const REPORT_OUT = '/tmp/pr-review-report.json';
 try { unlinkSync(REPORT_OUT); } catch {}
-spawnSync('node', ['qa-runner-v2.mjs', instruction], {
+const AGENT_TIMEOUT_MS = Number(env('AGENT_TIMEOUT_MS', '600000')); // hard cap: a hung browser can never block the runner
+const run = spawnSync('node', ['qa-runner-v2.mjs', instruction], {
   stdio: 'inherit',
-  env: { ...process.env, DIST_DIR: DIST, REPORT_OUT, MAX_TURNS: env('MAX_TURNS', '16') },
+  timeout: AGENT_TIMEOUT_MS,
+  killSignal: 'SIGKILL',
+  env: { ...process.env, DIST_DIR: DIST, REPORT_OUT, MAX_TURNS: env('MAX_TURNS', '14') },
 });
+const timedOut = run.signal === 'SIGKILL' || run.error?.code === 'ETIMEDOUT';
 
-let verdict = 'UNKNOWN', report = '(agent produced no report)';
+let verdict = 'UNKNOWN', report = timedOut
+  ? `Agent run exceeded the ${Math.round(AGENT_TIMEOUT_MS / 60000)}-minute cap and was stopped; partial exploration only. (${pct}% of pixels changed vs stable.)`
+  : '(agent produced no report)';
 if (existsSync(REPORT_OUT)) {
   try { const j = JSON.parse(readFileSync(REPORT_OUT, 'utf8')); verdict = j.verdict || verdict; report = j.report || report; } catch {}
 }
@@ -120,5 +130,5 @@ if (id) {
   writeFileSync(`${OUT}/comment.md`, comment);
   gh(['pr', 'comment', PR, '-R', REPO, '--body-file', `${OUT}/comment.md`]);
 }
-console.log(`agent-review: interactive+diff review posted on PR #${PR} (verdict ${verdict}, diff ${pct}%)`);
+console.log(`agent-review: review posted on PR #${PR} (verdict ${verdict}, diff ${pct}%, timedOut=${timedOut})`);
 process.exit(0);

--- a/.github/qa/agent-review.mjs
+++ b/.github/qa/agent-review.mjs
@@ -1,34 +1,22 @@
 #!/usr/bin/env node
 /**
- * Agent QA review (advisory).
+ * Agent QA review (advisory, non-gating).
  *
- * Builds-aware, perceptual review of a PR's CaaS build on the REAL
- * business.adobe.com collection page. Pipeline:
+ * Builds-aware perceptual review of a PR's CaaS build on the REAL
+ * business.adobe.com collection page:
  *   inject the PR's local dist into the live page via CDP request interception
  *   -> screenshot PR build vs current stable -> pixel diff
  *   -> hand (PR screenshot, stable screenshot, diff image, PR code diff, PR
  *      title+description) to a Claude judge via the Adobe LLM proxy
- *   -> post the findings as a PR comment.
+ *   -> post the findings as a PR comment. Only ever comments.
  *
- * Non-gating: this only ever comments. The deterministic gates (unit / WDIO
- * e2e / pa11y) live elsewhere. The agent's job here is judgment + exploration
- * on the real page, which can't be a deterministic on/off check.
- *
- * Required env:
- *   PR_NUMBER         PR to review
- *   IMS_ACCESS_TOKEN  bearer for the LLM proxy (repo secret)
- *   PROXY_URL         LLM proxy /v1/messages endpoint (LLM_PROXY_ENDPOINT secret)
- *   GH_TOKEN          token for `gh pr comment`
- * Optional env:
- *   GH_REPO (default adobecom/caas), DIST_DIR (default ../../dist),
- *   CDP_URL (default http://127.0.0.1:9222), BASE_URL, CAASVER (default 0.53.0),
- *   MODEL (default claude-sonnet-4-6), OUT_DIR (default ./agent-review-out),
- *   RUN_URL (link back to the workflow run, for the comment).
+ * Required env: PR_NUMBER, IMS_ACCESS_TOKEN, PROXY_URL, GH_TOKEN
+ * Optional: GH_REPO, DIST_DIR, CDP_URL, BASE_URL, CAASVER, MODEL, OUT_DIR, RUN_URL
  */
 import { chromium } from 'playwright';
 import pixelmatch from 'pixelmatch';
 import { PNG } from 'pngjs';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 
 const env = (k, d) => process.env[k] ?? d;
@@ -44,20 +32,27 @@ const MODEL = env('MODEL', 'claude-sonnet-4-6');
 const OUT = env('OUT_DIR', 'agent-review-out');
 const RUN_URL = env('RUN_URL', '');
 
-if (!PR || !TOKEN || !PROXY) {
-  console.error('Missing required env: PR_NUMBER, IMS_ACCESS_TOKEN, PROXY_URL');
-  process.exit(1);
-}
+// Strict validation — these flow into subprocess calls.
+if (!/^\d+$/.test(PR || '')) { console.error('PR_NUMBER must be a positive integer'); process.exit(1); }
+if (!/^[\w.-]+\/[\w.-]+$/.test(REPO)) { console.error('GH_REPO must be owner/repo'); process.exit(1); }
+if (!TOKEN || !PROXY) { console.error('Missing IMS_ACCESS_TOKEN / PROXY_URL'); process.exit(1); }
 mkdirSync(OUT, { recursive: true });
-const sh = (c) => execSync(c, { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
+
+// No shell: execFileSync with an explicit args array (no injection surface).
+const gh = (args) => execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
 const ct = (f) => (f.endsWith('.css') ? 'text/css' : 'application/javascript');
 const b64 = (p) => readFileSync(p).toString('base64');
+// Strip token-shaped strings before sending PR text to the external proxy.
+const redact = (s) => (s || '').replace(
+  /\b(gh[pousr]_[A-Za-z0-9]{20,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}|AKIA[0-9A-Z]{16})\b/g,
+  '[REDACTED]',
+);
 
-// 1) PR context: intent (title/body) + what changed (files/diff)
-const meta = JSON.parse(sh(`gh pr view ${PR} -R ${REPO} --json title,body,files`));
+// 1) PR context
+const meta = JSON.parse(gh(['pr', 'view', PR, '-R', REPO, '--json', 'title,body,files']));
 let codeDiff = '';
-try { codeDiff = sh(`gh pr diff ${PR} -R ${REPO}`); } catch { /* diff optional */ }
-codeDiff = codeDiff.slice(0, 12000);
+try { codeDiff = gh(['pr', 'diff', PR, '-R', REPO]); } catch { /* optional */ }
+codeDiff = redact(codeDiff.slice(0, 12000));
 const changedFiles = (meta.files || []).map((f) => f.path).join('\n').slice(0, 1500);
 
 // 2) screenshots: PR build injected vs current stable, on the same real page
@@ -86,12 +81,14 @@ await shot(true, `${OUT}/pr.png`);
 await shot(false, `${OUT}/stable.png`);
 await browser.close();
 
-// 3) pixel diff (the deterministic clue we hand the agent)
+// 3) pixel diff — crop both to the common rectangle so buffers match exactly
 const a = PNG.sync.read(readFileSync(`${OUT}/pr.png`));
 const b = PNG.sync.read(readFileSync(`${OUT}/stable.png`));
 const w = Math.min(a.width, b.width), h = Math.min(a.height, b.height);
+const ca = new PNG({ width: w, height: h }); PNG.bitblt(a, ca, 0, 0, w, h, 0, 0);
+const cb = new PNG({ width: w, height: h }); PNG.bitblt(b, cb, 0, 0, w, h, 0, 0);
 const diff = new PNG({ width: w, height: h });
-const changed = pixelmatch(a.data, b.data, diff.data, w, h, { threshold: 0.12, includeAA: false });
+const changed = pixelmatch(ca.data, cb.data, diff.data, w, h, { threshold: 0.12, includeAA: false });
 writeFileSync(`${OUT}/diff.png`, PNG.sync.write(diff));
 const pct = (100 * changed / (w * h)).toFixed(2);
 
@@ -101,15 +98,15 @@ const prompt = [
   'rendered on the REAL business.adobe.com page.',
   '',
   `PR title: ${meta.title}`,
-  `PR description:\n${(meta.body || '(none)').slice(0, 2000)}`,
+  `PR description:\n${redact(meta.body || '(none)').slice(0, 2000)}`,
   `Changed files:\n${changedFiles}`,
   '',
-  'Code diff (truncated):',
+  'Code diff (truncated, secrets redacted):',
   codeDiff || '(unavailable)',
   '',
   `You are given three images: (1) the page with THIS PR's build injected, (2) the current stable build, (3) a pixel-diff highlighting changes. ${pct}% of pixels differ.`,
-  'Use the diff and code diff as clues — note that some diff is just different cards loading (content noise), which you should ignore; focus on layout/styling/readability/a11y.',
-  'Report ONLY things that look off, broken, or regressed (truncated text, broken layout, bad contrast, missing/overlapping cards, unintended styling), and tie each to the change when you can.',
+  'Some diff is just different cards loading (content noise) — ignore that; focus on layout/styling/readability/a11y.',
+  'Report ONLY things that look off, broken, or regressed, and tie each to the change when you can.',
   'If nothing looks wrong, say so in one line. Be concise and specific.',
 ].join('\n');
 
@@ -140,7 +137,7 @@ try {
   else { findings = `(agent judge unavailable: HTTP ${res.status})`; }
 } catch (e) { findings = `(agent judge error: ${String(e).slice(0, 200)})`; }
 
-// 5) post advisory PR comment
+// 5) post advisory PR comment (no shell)
 const comment = [
   '## 🤖 Agent QA review — visual + perceptual (advisory, non-blocking)',
   '',
@@ -151,6 +148,6 @@ const comment = [
   RUN_URL ? `_Screenshots and the pixel diff are in the [workflow artifacts](${RUN_URL})._` : '',
 ].join('\n');
 writeFileSync(`${OUT}/comment.md`, comment);
-sh(`gh pr comment ${PR} -R ${REPO} --body-file ${OUT}/comment.md`);
+gh(['pr', 'comment', PR, '-R', REPO, '--body-file', `${OUT}/comment.md`]);
 console.log(`agent-review: posted comment on PR #${PR} (pct changed ${pct})`);
 process.exit(0);

--- a/.github/qa/package-lock.json
+++ b/.github/qa/package-lock.json
@@ -8,7 +8,9 @@
       "name": "caas-qa-audit-runner",
       "version": "1.0.0",
       "dependencies": {
-        "playwright": "^1.48.0"
+        "pixelmatch": "^6.0.0",
+        "playwright": "^1.48.0",
+        "pngjs": "^7.0.0"
       }
     },
     "node_modules/fsevents": {
@@ -22,6 +24,18 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pixelmatch": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-6.0.0.tgz",
+      "integrity": "sha512-FYpL4XiIWakTnIqLqvt3uN4L9B3TsuHIvhLILzTiJZMJUsGvmKNeL4H3b6I99LRyerK9W4IuOXw+N28AtRgK2g==",
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^7.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
       }
     },
     "node_modules/playwright": {
@@ -50,6 +64,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     }
   }

--- a/.github/qa/package.json
+++ b/.github/qa/package.json
@@ -5,6 +5,8 @@
   "description": "Playwright + tooling for the AI-driven QA audit workflow. Isolated from the main CaaS package.json so adding/upgrading Playwright doesn't touch the React build.",
   "type": "module",
   "dependencies": {
-    "playwright": "^1.48.0"
+    "pixelmatch": "^6.0.0",
+    "playwright": "^1.48.0",
+    "pngjs": "^7.0.0"
   }
 }

--- a/.github/qa/provision-runner.sh
+++ b/.github/qa/provision-runner.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Provision a macOS machine as a CaaS self-hosted QA runner.
+# Captures everything the agent-review job needs at the machine level, so a new
+# Mac is reproducible from source control (the agent code itself lives in
+# .github/qa and is pulled on checkout — this only sets up the host).
+#
+# Prereqs: Homebrew, Google Chrome installed, the machine signed in (auto-login).
+set -euo pipefail
+H="$HOME"
+
+echo "1/3  Node 18 (webpack 3 build needs Node <19) + gh + git"
+/opt/homebrew/bin/brew install node@18 gh git || true
+
+echo "2/3  Persistent real Chrome with remote debugging (CDP) for the agent to attach to"
+PLIST="$H/Library/LaunchAgents/com.adobecom.caas-qa-chrome.plist"
+cat > "$PLIST" <<PL
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>com.adobecom.caas-qa-chrome</string>
+  <key>ProgramArguments</key><array>
+    <string>/Applications/Google Chrome.app/Contents/MacOS/Google Chrome</string>
+    <string>--remote-debugging-port=9222</string>
+    <string>--remote-debugging-address=127.0.0.1</string>
+    <string>--user-data-dir=$H/caas-qa-chrome-profile</string>
+    <string>--no-first-run</string>
+    <string>--no-default-browser-check</string>
+    <string>--disable-session-crashed-bubble</string>
+    <string>--hide-crash-restore-bubble</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardOutPath</key><string>$H/caas-qa-chrome.out.log</string>
+  <key>StandardErrorPath</key><string>$H/caas-qa-chrome.err.log</string>
+</dict></plist>
+PL
+launchctl bootstrap "gui/$(id -u)" "$PLIST" 2>/dev/null || launchctl load -w "$PLIST" || true
+
+echo "3/3  Point the Actions runner at the persistent Chrome (CDP) for every job"
+RUNNER_ENV="$H/actions-runner/.env"
+if [ -f "$RUNNER_ENV" ]; then
+  grep -q '^CDP_URL=' "$RUNNER_ENV" || echo 'CDP_URL=http://127.0.0.1:9222' >> "$RUNNER_ENV"
+else
+  echo "  (runner not registered yet — see below)"
+fi
+
+echo
+echo "Done. Verify Chrome/CDP:  curl -s http://127.0.0.1:9222/json/version"
+echo
+echo "Register the runner (manual, one-time — get a token from"
+echo "GitHub > adobecom/caas > Settings > Actions > Runners > New self-hosted runner):"
+echo "  cd ~/actions-runner && ./config.sh --url https://github.com/adobecom/caas \\"
+echo "    --token <REG_TOKEN> --labels self-hosted,ARM64,qa-audit --unattended"
+echo "  echo 'CDP_URL=http://127.0.0.1:9222' >> ~/actions-runner/.env"
+echo "  # then run it via launchd (run.sh) so it survives reboots"

--- a/.github/qa/qa-runner-v2.mjs
+++ b/.github/qa/qa-runner-v2.mjs
@@ -645,6 +645,17 @@ async function main() {
         console.log('[browser] headless chromium with bot-evasion args\n');
     }
 
+    if (process.env.DIST_DIR) {
+        const __distRoot = process.env.DIST_DIR;
+        const __allow = new Set(['main.min.js', 'app.css', 'react.umd.js', 'react.dom.umd.js']);
+        await context.route('**/caas-libs/**', async (route) => {
+            const f = route.request().url().split('?')[0].split('/').pop();
+            if (!__allow.has(f)) return route.continue();
+            try { await route.fulfill({ path: __distRoot + '/' + f }); } catch { await route.continue(); }
+        });
+        console.log('[browser] injecting PR dist for caas-libs from ' + __distRoot + '\n');
+    }
+
     const consoleErrors = [];
     page.on('console', (m) => { if (m.type() === 'error') consoleErrors.push(m.text()); });
     page.on('pageerror', (e) => consoleErrors.push('[pageerror] ' + e.message));
@@ -944,6 +955,9 @@ async function main() {
     if (process.env.GITHUB_STEP_SUMMARY) {
         writeFileSync(process.env.GITHUB_STEP_SUMMARY,
             `## ${verdict} ${instruction.slice(0, 80)}\n\n\`\`\`\n${report}\n\`\`\`\n`, { flag: 'a' });
+    }
+    if (process.env.REPORT_OUT) {
+        try { writeFileSync(process.env.REPORT_OUT, JSON.stringify({ verdict, report })); } catch (e) {}
     }
     process.exit(verdict === 'PASS' ? 0 : 1);
 }

--- a/.github/workflows/qa-agent-review.yml
+++ b/.github/workflows/qa-agent-review.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   agent-review:
     runs-on: [self-hosted, qa-audit]   # the Mini — only runner with the persistent Chrome/CDP
+    timeout-minutes: 20
     # Same-repo PRs only (public repo + self-hosted runner); manual dispatch always allowed.
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:

--- a/.github/workflows/qa-agent-review.yml
+++ b/.github/workflows/qa-agent-review.yml
@@ -1,0 +1,79 @@
+name: Agent QA Review
+
+# Advisory, non-blocking. Builds the PR's CaaS bundle, injects it into the live
+# business.adobe.com collection page on a self-hosted runner with a persistent
+# real Chrome (CDP), screenshots PR vs stable, pixel-diffs, and has a Claude
+# judge post a perceptual-review comment. Deterministic gates (unit/WDIO/pa11y)
+# live in the existing Pull Request workflow; this only ever comments.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review (leave blank to backfill ALL open PRs)'
+        required: false
+        type: string
+
+concurrency:
+  group: agent-qa-${{ github.event.pull_request.number || inputs.pr_number || 'all' }}
+  cancel-in-progress: true
+
+jobs:
+  agent-review:
+    runs-on: [self-hosted, ARM64]
+    # Same-repo PRs only (public repo + self-hosted runner); manual dispatch always allowed.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Build the PR's CaaS dist
+        run: |
+          npm ci
+          NODE_OPTIONS=--openssl-legacy-provider npm run build
+
+      - name: Install agent-review deps
+        working-directory: .github/qa
+        run: npm ci
+
+      - name: Run agent QA review
+        working-directory: .github/qa
+        env:
+          GH_REPO: ${{ github.repository }}
+          DIST_DIR: ${{ github.workspace }}/dist
+          CDP_URL: http://127.0.0.1:9222
+          IMS_ACCESS_TOKEN: ${{ secrets.IMS_ACCESS_TOKEN }}
+          PROXY_URL: ${{ secrets.LLM_PROXY_ENDPOINT }}
+          MODEL: ${{ secrets.LLM_MODEL }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EVENT_PR: ${{ github.event.pull_request.number }}
+          INPUT_PR: ${{ inputs.pr_number }}
+        run: |
+          PRS="${EVENT_PR:-$INPUT_PR}"
+          # workflow_dispatch with no number => backfill every open PR
+          if [ -z "$PRS" ]; then
+            PRS=$(gh pr list -R "$GH_REPO" --state open --json number --jq '.[].number')
+          fi
+          echo "Reviewing PR(s): $PRS"
+          for n in $PRS; do
+            echo "::group::PR #$n"
+            PR_NUMBER="$n" OUT_DIR="agent-review-out/pr-$n" node agent-review.mjs || echo "PR #$n review failed (non-blocking)"
+            echo "::endgroup::"
+          done
+
+      - name: Upload screenshots + diffs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-review-${{ github.run_id }}
+          path: .github/qa/agent-review-out/
+          retention-days: 14

--- a/.github/workflows/qa-agent-review.yml
+++ b/.github/workflows/qa-agent-review.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   agent-review:
-    runs-on: [self-hosted, ARM64]
+    runs-on: [self-hosted, qa-audit]   # the Mini — only runner with the persistent Chrome/CDP
     # Same-repo PRs only (public repo + self-hosted runner); manual dispatch always allowed.
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:


### PR DESCRIPTION
## Agent QA review (advisory, non-blocking)

Adds an agent-driven **visual + perceptual** QA review that runs on each PR and posts a comment — it never gates the merge. Deterministic gates (unit, WDIO e2e, pa11y) are unchanged.

### How it works
- Builds the PR's CaaS `dist`, then on a self-hosted runner with a persistent real Chrome it **injects that build into the live business.adobe.com collection page via CDP request interception** (so it tests the PR code on the real page, past Akamai, with no hosting).
- Screenshots the PR build vs the current stable build and computes a pixel diff.
- Hands the agent the two screenshots, the diff image, the **PR code diff**, and the **PR title/description** (intent), via the Adobe LLM proxy, and posts its findings as a PR comment.

### Triggers
- `pull_request` (opened/synchronize/reopened) — same-repo only.
- `workflow_dispatch` with optional `pr_number`; **blank = backfill every open PR**.

### Files
- `.github/qa/agent-review.mjs` — the review script.
- `.github/workflows/qa-agent-review.yml` — the workflow.
- `.github/qa/provision-runner.sh` — reproducible host setup (Node 18, persistent Chrome-CDP service, runner `CDP_URL`).
- `.github/qa/package.json` — adds `pixelmatch` + `pngjs`.

Draft: pending a live `workflow_dispatch` test run to tune waits / prompt / diff threshold.
