### PR TITLE
chore(mwpw-184989): nudge card bottom padding to 8px

### DIFF
--- a/less/components/consonant/cards/card.less
+++ b/less/components/consonant/cards/card.less
@@ -6,7 +6,7 @@
 
     .full-width;
 
-    padding-bottom: 7px;
+    padding-bottom: 8px;
     text-align: left;
     border: 1px solid @consonantGray300;
     border-radius: 4px;


### PR DESCRIPTION
Small visual tweak: bump .consonant-Card bottom padding from 7px to 8px for slightly more consistent grid rhythm. (QA-agent test PR, will be closed.)