### PR TITLE
fix(mwpw-184989): QA agent tests bare prod URL (no hardcoded caasver)

### DIFF
--- a/.github/qa/agent-review.mjs
+++ b/.github/qa/agent-review.mjs
@@ -17,7 +17,7 @@ const REPO = env('GH_REPO', 'adobecom/caas');
 const DIST = env('DIST_DIR');
 const CDP = env('CDP_URL', 'http://127.0.0.1:9222');
 const BASE = env('BASE_URL', 'https://business.adobe.com/resources/main.html');
-const CAASVER = env('CAASVER', '0.53.0');
+const CAASVER = env('CAASVER', ''); // optional version pin; default = bare URL, no query param
 const RUN_URL = env('RUN_URL', '');
 const OUT = resolve(env('OUT_DIR', 'agent-review-out'));
 if (!/^\d+$/.test(PR || '')) { console.error('PR_NUMBER must be a positive integer'); process.exit(1); }
@@ -35,7 +35,7 @@ let diff = '';
 try { diff = gh(['pr', 'diff', PR, '-R', REPO]); } catch {}
 
 // 1) capture PR-vs-stable visual diff (the guide)
-const url = `${BASE}?caasver=${CAASVER}`;
+const url = CAASVER ? `${BASE}?caasver=${CAASVER}` : BASE;
 let pct = 'n/a';
 try {
   const browser = await chromium.connectOverCDP(CDP);


### PR DESCRIPTION
The agent QA review pinned ?caasver=0.53.0 to force an interceptable bundle request. Not needed: the page requests caas-libs/stable/* on its own and our interception matches any caas-libs/** request. Now it loads the bare prod URL (zero query params), and the stable baseline becomes literally what is live, not a pinned version. Verified on the runner: bare URL serves all four bundle files (200) from the PR build and renders cards with no console errors. Optional CAASVER env remains as an escape hatch.