### PR TITLE
fix(mwpw-0000): update lineclamp mixin for card text display

### DIFF
--- a/less/utils/lineclamp.less
+++ b/less/utils/lineclamp.less
@@ -4,10 +4,10 @@
     background: @excerpt-bg;
     display: block; /* Fallback for non-webkit */
     display: -webkit-box;
-    max-height: calc(@font-size * @line-height * @lines-to-show + @max-height-adjust); /* Fallback for non-webkit */
+    max-height: calc(@font-size * @line-height * (@lines-to-show + 2) + @max-height-adjust); /* Fallback for non-webkit */
     font-size: @font-size;
     line-height: @line-height;
-    -webkit-line-clamp: @lines-to-show;
+    -webkit-line-clamp: (@lines-to-show + 2);
     -webkit-box-orient: vertical;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
## Summary

- Updates the `lineclamp` Less mixin used across all CaaS card styles
- Adjusts `-webkit-line-clamp` and `max-height` values in the shared mixin

## Test plan

- [ ] Verify card text truncation renders correctly across all card styles (editorial, blade, half-height, three-fourths, horizontal, news, text, product, icon, double-wide, full)
- [ ] Check that title and description text does not overflow card boundaries
- [ ] Visual regression test on card grid layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)