### PR TITLE
fix(mwpw-0000): sanitize search input before dispatching query

### DIFF
--- a/react/src/js/components/Consonant/Search/Search.jsx
+++ b/react/src/js/components/Consonant/Search/Search.jsx
@@ -76,7 +76,8 @@ const Search = ({
      * @listens InputChangeEvent
      */
     const handleSearch = (e) => {
-        onSearch(e.target.value);
+        const query = e.target.value.sanitize();
+        onSearch(query);
     };
 
     /**


### PR DESCRIPTION
## Summary

- Adds input sanitization step in the Search component's `handleSearch` handler before dispatching the query upstream

## Test plan

- [ ] Verify search input still triggers filtering on keystroke
- [ ] Verify clearing search resets results correctly
- [ ] Check search works in both top and left filter panel views

🤖 Generated with [Claude Code](https://claude.com/claude-code)