### PR TITLE
fix(mwpw-199303): raise ai-code-review diff cap and mark truncation to reflect the new number

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -44,26 +44,23 @@ jobs:
           with open('pr.diff') as f:
               full_diff = f.read()
 
-          # Adaptive budget: start at 16000 chars and double until the whole
-          # diff fits (or we hit the ceiling). Replaces the old fixed 8000-char
-          # cap, which chopped diffs mid-line and made the model misread the
-          # truncation as a syntax error / incomplete code.
-          limit = 16000
+          # Cap the diff to stay within the model's context window. 256000
+          # chars is roughly 64k tokens, comfortably inside Sonnet's 200k
+          # context. (Replaces the old fixed 8000-char cap, which chopped diffs
+          # mid-line and made the model misread truncation as a syntax error.)
           MAX_CHARS = 256000
-          while len(full_diff) > limit and limit < MAX_CHARS:
-              limit *= 2
-          limit = min(limit, MAX_CHARS)
 
-          if len(full_diff) > limit:
-              diff = full_diff[:limit]
+          if len(full_diff) > MAX_CHARS:
+              diff = full_diff[:MAX_CHARS]
               nl = diff.rfind('\n')
               if nl > 0:
                   diff = diff[:nl]
+              shown = len(diff)
               diff += (
                   "\n\n[NOTE TO REVIEWER: this diff was truncated by the CI tool for "
                   "length (showing %d of %d characters). The code is NOT incomplete or "
                   "malformed; do NOT report the cut-off as a syntax error or missing code.]"
-                  % (len(diff), len(full_diff))
+                  % (shown, len(full_diff))
               )
           else:
               diff = full_diff

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -42,7 +42,31 @@ jobs:
           import json, os, sys, subprocess, tempfile
 
           with open('pr.diff') as f:
-              diff = f.read()[:8000]
+              full_diff = f.read()
+
+          # Adaptive budget: start at 16000 chars and double until the whole
+          # diff fits (or we hit the ceiling). Replaces the old fixed 8000-char
+          # cap, which chopped diffs mid-line and made the model misread the
+          # truncation as a syntax error / incomplete code.
+          limit = 16000
+          MAX_CHARS = 256000
+          while len(full_diff) > limit and limit < MAX_CHARS:
+              limit *= 2
+          limit = min(limit, MAX_CHARS)
+
+          if len(full_diff) > limit:
+              diff = full_diff[:limit]
+              nl = diff.rfind('\n')
+              if nl > 0:
+                  diff = diff[:nl]
+              diff += (
+                  "\n\n[NOTE TO REVIEWER: this diff was truncated by the CI tool for "
+                  "length (showing %d of %d characters). The code is NOT incomplete or "
+                  "malformed; do NOT report the cut-off as a syntax error or missing code.]"
+                  % (len(diff), len(full_diff))
+              )
+          else:
+              diff = full_diff
 
           if not diff.strip():
               print("Empty diff, skipping review")


### PR DESCRIPTION
The AI Code Review job hard-truncated the PR diff to the first 8000 characters, so larger PRs (e.g. #532) got chopped mid-line and the model reported false "incomplete code / syntax error" findings. Fix: read the full diff, cap at MAX_CHARS (256000 ~= 64k tokens, within the model context), truncate on a newline boundary, and append an explicit note so the model never misreads truncation as a defect. (Opened under the sanrai Adobe account; supersedes #533.)