### PR TITLE
feat(mwpw-184989): multi-page agent QA review with PR-aware routing

### DIFF
--- a/.github/qa/agent-review.mjs
+++ b/.github/qa/agent-review.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /** Multi-page interactive agent QA review (advisory, non-blocking).
- *  For each PR-relevant page in the covering set: capture a PR-build-vs-stable
- *  visual diff, drive the interactive qa-runner with a page-specific
- *  instruction, then post ONE combined deduped PR comment. */
+ *  For each PR-relevant page: capture a PR-build-vs-stable visual diff
+ *  (segmented into bands for very tall pages), drive the interactive
+ *  qa-runner with a page-specific instruction, post ONE combined comment. */
 import { execFileSync, spawnSync } from 'node:child_process';
 import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -30,7 +30,6 @@ const meta = JSON.parse(gh(['pr', 'view', PR, '-R', REPO, '--json', 'title,body,
 let diff = ''; try { diff = gh(['pr', 'diff', PR, '-R', REPO]); } catch {}
 const changed = (meta.files || []).map((f) => f.path).join('\n');
 
-// ---- The covering set (validated against live pages) ----
 const OR = 'This collection uses OR filtering: selecting one filter narrows the full set, but selecting a SECOND filter in the same group WIDENS the results (union) -- treat that increase as CORRECT, not a bug.';
 const PAGES = [
   { id: 'A-left-hub', url: 'https://business.adobe.com/customer-success-stories.html',
@@ -46,19 +45,18 @@ const PAGES = [
     triggers: /Carousel|Grid|Card\.jsx/i,
     instr: `Carousel collection. Cards render in a horizontal carousel. Click next/prev (or scroll) -> the carousel advances and shows new cards. Verify the arrows/affordances render and nothing is clipped or overlapping.` },
   { id: 'E-gallery', url: 'https://milo.adobe.com/drafts/caas/card-styles',
-    triggers: /Cards\/|Card\.jsx|CardContent|CardHeader|CardFooter/i, fullPage: true, wait: 22000,
-    instr: `Card-style gallery: a TALL page rendering every card style. VISUAL review only -- you do NOT need to interact. A full-page PR-vs-stable pixel diff was captured. Load the diff, find the magenta regions (where rendering changed), and report each card style that looks broken: truncated/clipped text, broken/missing image, misaligned or overlapping elements, wrong spacing, or a style that fails to render. If the diff is essentially empty, say all styles render cleanly. End with done(report, verdict) promptly.` },
+    triggers: /Cards\/|Card\.jsx|CardContent|CardHeader|CardFooter/i, fullPage: true, segment: true, bandHeight: 1500, wait: 22000,
+    instr: `Card-style gallery: a TALL page rendering every card style. VISUAL review only -- you do NOT need to interact. The full-page diff is split into vertical bands; load the changed bands and report each card style that looks broken: truncated/clipped text, broken/missing image, misaligned or overlapping elements, wrong spacing, or a style that fails to render. If no bands changed, say all styles render cleanly. End with done(report, verdict) promptly.` },
 ];
 
-// Shared change (Card.jsx / Container / Helpers / app / any LESS) -> review all pages.
 const SHARED = /Card\.jsx|Container\.jsx|Helpers\/|app\.jsx|\.less/i;
 const isShared = SHARED.test(changed);
 let selected = isShared ? PAGES : PAGES.filter((p) => p.triggers.test(changed));
-if (selected.length === 0) selected = [PAGES[0]]; // smoke
+if (selected.length === 0) selected = [PAGES[0]];
 console.log(`Selected ${selected.length} page(s): ${selected.map((p) => p.id).join(', ')}`);
 
 async function captureDiff(url, tag, opts = {}) {
-  let pct = 'n/a';
+  let pct = 'n/a'; const bands = [];
   try {
     const browser = await chromium.connectOverCDP(CDP);
     const c = browser.contexts()[0] || (await browser.newContext());
@@ -73,40 +71,64 @@ async function captureDiff(url, tag, opts = {}) {
       }
       await p.goto(url, { waitUntil: 'load', timeout: 45000 }).catch(() => {});
       await p.waitForTimeout(opts.wait || 15000);
-      const card = await p.$('.consonant-Card'); if (card) await card.scrollIntoViewIfNeeded().catch(() => {});
-      await p.waitForTimeout(1500); await p.screenshot({ path: out, fullPage: !!opts.fullPage }); await p.close();
+      if (opts.fullPage) {
+        await p.evaluate(async () => { const H = document.body.scrollHeight; for (let y = 0; y < H; y += 1000) { window.scrollTo(0, y); await new Promise((r) => setTimeout(r, 150)); } window.scrollTo(0, 0); });
+        await p.waitForTimeout(1500);
+      } else {
+        const card = await p.$('.consonant-Card'); if (card) await card.scrollIntoViewIfNeeded().catch(() => {});
+        await p.waitForTimeout(1500);
+      }
+      await p.screenshot({ path: out, fullPage: !!opts.fullPage }); await p.close();
     };
     await shot(true, `${OUT}/${tag}-pr.png`);
     await shot(false, `${OUT}/${tag}-stable.png`);
     await browser.close();
     const a = PNG.sync.read(readFileSync(`${OUT}/${tag}-pr.png`)), b = PNG.sync.read(readFileSync(`${OUT}/${tag}-stable.png`));
-    const w = Math.min(a.width, b.width), h = Math.min(a.height, b.height);
-    const ca = new PNG({ width: w, height: h }); PNG.bitblt(a, ca, 0, 0, w, h, 0, 0);
-    const cb = new PNG({ width: w, height: h }); PNG.bitblt(b, cb, 0, 0, w, h, 0, 0);
-    const d = new PNG({ width: w, height: h });
-    const n = pixelmatch(ca.data, cb.data, d.data, w, h, { threshold: 0.12, includeAA: false });
-    writeFileSync(`${OUT}/${tag}-diff.png`, PNG.sync.write(d)); pct = (100 * n / (w * h)).toFixed(2);
+    const w = Math.min(a.width, b.width), Ht = Math.min(a.height, b.height);
+    if (opts.segment) {
+      const BH = opts.bandHeight || 1500; let changed2 = 0;
+      for (let y = 0, i = 0; y < Ht; y += BH, i++) {
+        const bh = Math.min(BH, Ht - y);
+        const pa = new PNG({ width: w, height: bh }); PNG.bitblt(a, pa, 0, y, w, bh, 0, 0);
+        const pb = new PNG({ width: w, height: bh }); PNG.bitblt(b, pb, 0, y, w, bh, 0, 0);
+        const pd = new PNG({ width: w, height: bh });
+        const n = pixelmatch(pa.data, pb.data, pd.data, w, bh, { threshold: 0.12, includeAA: false });
+        changed2 += n;
+        const bp = 100 * n / (w * bh);
+        if (bp > 0.3) { const fp = `${OUT}/${tag}-band${i}-diff.png`; writeFileSync(fp, PNG.sync.write(pd)); bands.push({ i, pct: bp.toFixed(2), path: fp }); }
+      }
+      pct = (100 * changed2 / (w * Ht)).toFixed(2);
+    } else {
+      const ca = new PNG({ width: w, height: Ht }); PNG.bitblt(a, ca, 0, 0, w, Ht, 0, 0);
+      const cb = new PNG({ width: w, height: Ht }); PNG.bitblt(b, cb, 0, 0, w, Ht, 0, 0);
+      const d = new PNG({ width: w, height: Ht });
+      const n = pixelmatch(ca.data, cb.data, d.data, w, Ht, { threshold: 0.12, includeAA: false });
+      writeFileSync(`${OUT}/${tag}-diff.png`, PNG.sync.write(d)); pct = (100 * n / (w * Ht)).toFixed(2);
+    }
   } catch (e) { console.log(`[${tag}] diff capture failed: ${String(e).slice(0, 120)}`); }
-  return pct;
+  return { pct, bands };
 }
 
 const sections = [];
 for (const page of selected) {
   console.log(`\n===== ${page.id} :: ${page.url} =====`);
-  const pct = await captureDiff(page.url, page.id, { fullPage: page.fullPage, wait: page.wait });
+  const { pct, bands } = await captureDiff(page.url, page.id, { fullPage: page.fullPage, wait: page.wait, segment: page.segment, bandHeight: page.bandHeight });
+  const diffHint = bands.length
+    ? `The full-page pixel diff was split into vertical bands (this page is very tall); overall ${pct}% changed, ${bands.length} band(s) changed. Load them: load_screenshots([${bands.map((bb) => `"${bb.path}"`).join(', ')}]). NOTE: a change to a card's height (e.g. a truncated title) shifts every card BELOW it upward, so several changed bands can be ONE root cause -- report the root cause(s), not each shifted band.`
+    : `A pixel diff of the PR build vs current stable was captured; ${pct}% of pixels changed. Magenta regions mark where the PR changed rendering. Call load_screenshots(["${OUT}/${page.id}-diff.png"]) once to see them, then interact.`;
   const instruction = [
     `Target URL: ${page.url}`, '',
     `You are QA-reviewing pull request #${PR}. The PR's CaaS build is injected into this live page, so you are testing the PR's code on the real page.`,
-    `A pixel diff of the PR build vs current stable was captured; ${pct}% of pixels changed. Magenta regions mark where the PR changed rendering. Call load_screenshots(["${OUT}/${page.id}-diff.png"]) once to see them, then interact.`,
+    diffHint,
     `PR title: ${meta.title}`,
     `Code diff (truncated, secrets redacted): ${redact(diff).slice(0, 5000)}`,
     '', page.instr, '',
-    'Interact like a real user per the instruction; use the diff to focus where the PR changed things. Report anything broken/truncated/misaligned/wrong; if clean, say so. End with done(report, verdict).',
+    'Report anything broken/truncated/misaligned/wrong; if clean, say so. End with done(report, verdict).',
   ].join('\n');
   const REPORT_OUT = `/tmp/pr-review-${page.id}.json`; try { unlinkSync(REPORT_OUT); } catch {}
   const run = spawnSync('node', ['qa-runner-v2.mjs', instruction], {
     stdio: 'inherit', timeout: Number(env('AGENT_TIMEOUT_MS', '180000')), killSignal: 'SIGKILL',
-    env: { ...process.env, DIST_DIR: DIST, REPORT_OUT, MAX_TURNS: env('MAX_TURNS', '18') },
+    env: { ...process.env, DIST_DIR: DIST, REPORT_OUT, MAX_TURNS: env('MAX_TURNS', '16') },
   });
   const timedOut = run.signal === 'SIGKILL' || run.error?.code === 'ETIMEDOUT';
   let verdict = 'UNKNOWN', report = timedOut ? `Agent run exceeded the per-page time cap; partial only. (${pct}% pixels changed.)` : '(no report produced)';

--- a/.github/qa/agent-review.mjs
+++ b/.github/qa/agent-review.mjs
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
-/** Interactive agent QA review (advisory, non-blocking).
- *  1) Capture a PR-build-vs-stable visual diff on the live page (the guide).
- *  2) Drive the interactive qa-runner on the PR build, handing it the diff
- *     image + the PR code diff as context.
- *  3) Post a single deduped PR comment. Never gates. */
+/** Multi-page interactive agent QA review (advisory, non-blocking).
+ *  For each PR-relevant page in the covering set: capture a PR-build-vs-stable
+ *  visual diff, drive the interactive qa-runner with a page-specific
+ *  instruction, then post ONE combined deduped PR comment. */
 import { execFileSync, spawnSync } from 'node:child_process';
 import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -16,119 +15,120 @@ const PR = env('PR_NUMBER');
 const REPO = env('GH_REPO', 'adobecom/caas');
 const DIST = env('DIST_DIR');
 const CDP = env('CDP_URL', 'http://127.0.0.1:9222');
-const BASE = env('BASE_URL', 'https://business.adobe.com/resources/main.html');
-const CAASVER = env('CAASVER', ''); // optional version pin; default = bare URL, no query param
 const RUN_URL = env('RUN_URL', '');
 const OUT = resolve(env('OUT_DIR', 'agent-review-out'));
 if (!/^\d+$/.test(PR || '')) { console.error('PR_NUMBER must be a positive integer'); process.exit(1); }
 if (!DIST) { console.error('DIST_DIR required'); process.exit(1); }
 mkdirSync(OUT, { recursive: true });
 
-const gh = (args) => execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
+const gh = (a) => execFileSync('gh', a, { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
 const redact = (s) => (s || '').replace(/\b(gh[pousr]_[A-Za-z0-9]{20,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}|AKIA[0-9A-Z]{16})\b/g, '[REDACTED]');
 const ALLOW = new Set(['main.min.js', 'app.css', 'react.umd.js', 'react.dom.umd.js']);
 const ct = (f) => (f.endsWith('.css') ? 'text/css' : 'application/javascript');
 
-// PR context
 const meta = JSON.parse(gh(['pr', 'view', PR, '-R', REPO, '--json', 'title,body,files']));
-let diff = '';
-try { diff = gh(['pr', 'diff', PR, '-R', REPO]); } catch {}
+let diff = ''; try { diff = gh(['pr', 'diff', PR, '-R', REPO]); } catch {}
+const changed = (meta.files || []).map((f) => f.path).join('\n');
 
-// 1) capture PR-vs-stable visual diff (the guide)
-const url = CAASVER ? `${BASE}?caasver=${CAASVER}` : BASE;
-let pct = 'n/a';
-try {
-  const browser = await chromium.connectOverCDP(CDP);
-  const c = browser.contexts()[0] || (await browser.newContext());
-  const shot = async (inject, out) => {
-    const p = await c.newPage();
-    await p.setViewportSize({ width: 1280, height: 1800 });
-    if (inject) {
-      await p.route('**/caas-libs/**', async (r) => {
-        const f = r.request().url().split('?')[0].split('/').pop();
-        if (!ALLOW.has(f)) return r.continue();
-        try { await r.fulfill({ path: `${DIST}/${f}`, contentType: ct(f) }); } catch { await r.continue(); }
-      });
-    }
-    await p.goto(url, { waitUntil: 'load', timeout: 45000 }).catch(() => {});
-    await p.waitForTimeout(15000);
-    const card = await p.$('.consonant-Card');
-    if (card) await card.scrollIntoViewIfNeeded().catch(() => {});
-    await p.waitForTimeout(1500);
-    await p.screenshot({ path: out });
-    await p.close();
-  };
-  await shot(true, `${OUT}/pr.png`);
-  await shot(false, `${OUT}/stable.png`);
-  // Disconnect THIS CDP client (does not kill the persistent Chrome) so the
-  // qa-runner subprocess is the sole Playwright client — two concurrent clients
-  // on one browser cause navigation timeouts and hangs.
-  await browser.close();
-  const a = PNG.sync.read(readFileSync(`${OUT}/pr.png`)), b = PNG.sync.read(readFileSync(`${OUT}/stable.png`));
-  const w = Math.min(a.width, b.width), h = Math.min(a.height, b.height);
-  const ca = new PNG({ width: w, height: h }); PNG.bitblt(a, ca, 0, 0, w, h, 0, 0);
-  const cb = new PNG({ width: w, height: h }); PNG.bitblt(b, cb, 0, 0, w, h, 0, 0);
-  const d = new PNG({ width: w, height: h });
-  const n = pixelmatch(ca.data, cb.data, d.data, w, h, { threshold: 0.12, includeAA: false });
-  writeFileSync(`${OUT}/diff.png`, PNG.sync.write(d));
-  pct = (100 * n / (w * h)).toFixed(2);
-} catch (e) { console.log('visual-diff capture failed: ' + String(e).slice(0, 160)); }
+// ---- The covering set (validated against live pages) ----
+const OR = 'This collection uses OR filtering: selecting one filter narrows the full set, but selecting a SECOND filter in the same group WIDENS the results (union) -- treat that increase as CORRECT, not a bug.';
+const PAGES = [
+  { id: 'A-left-hub', url: 'https://business.adobe.com/customer-success-stories.html',
+    triggers: /Filters\/Left|CardFilterer|getFilteredCards|Helpers|Search|Sort|Pagination|Bookmark|Container|Card\.jsx/i,
+    instr: `Left-filter collection. ${OR} Open the left filter panel, select a filter -> results narrow, the count updates, a selected-filter chip appears. Add a second filter in the same group -> results WIDEN (OR). Clear All -> back to full. Pick a filter combination yielding nothing -> a no-results empty state shows (not a blank/broken grid). Search a query -> results filter and the matched term is highlighted. Change the Sort dropdown -> the visible order changes. Go to page 2 -> the URL gains page=2 and different cards show; navigate to that page-2 URL fresh -> it should restore page 2. Bookmark a card -> the icon toggles; open the saved view -> only saved cards show. Click a card -> opens the expected link/modal.` },
+  { id: 'B-top-panel', url: 'https://news.adobe.com/news?ch_News+articles=Experience%2520Cloud',
+    triggers: /Filters\/Top|Container|CardFilterer|getFilteredCards|Helpers|Card\.jsx/i,
+    instr: `Top-filter collection (a filter is pre-applied via the URL). Confirm the page loads already filtered to that selection. Open the top filter bar, change/add a filter -> results and count update. ${OR} Run a search -> results update.` },
+  { id: 'C-events', url: 'https://www.adobe.com/events.html',
+    triggers: /eventSort|Sort|timing|event|Container|Helpers|Card\.jsx/i,
+    instr: `Event collection (cards have dates). Verify the ordering looks right for events (upcoming first / dates ascending, not past-first). Check a register / save-your-spot banner card -> its CTA renders and is clickable. Apply a filter if present -> results update.` },
+  { id: 'D-carousel', url: 'https://www.adobe.com/max/2025/community.html',
+    triggers: /Carousel|Grid|Card\.jsx/i,
+    instr: `Carousel collection. Cards render in a horizontal carousel. Click next/prev (or scroll) -> the carousel advances and shows new cards. Verify the arrows/affordances render and nothing is clipped or overlapping.` },
+  { id: 'E-gallery', url: 'https://milo.adobe.com/drafts/caas/card-styles',
+    triggers: /Cards\/|Card\.jsx|CardContent|CardHeader|CardFooter/i,
+    instr: `Card-style gallery: every card style is rendered on one page. VISUAL review -- scan all styles for rendering regressions: truncated/clipped text, broken or missing images, misaligned/overlapping elements, wrong spacing, a style that fails to render. Use the visual diff to focus where the PR changed rendering.` },
+];
 
-// 2) interactive agent, guided by the diff + the PR code diff
-const instruction = [
-  `Target URL: ${url}`,
-  '',
-  `You are QA-reviewing pull request #${PR}. The PR's CaaS build is already injected into this live page, so you are testing the PR's code on the real business.adobe.com collection.`,
-  `A pixel diff of the PR build vs the current stable build was captured; ${pct}% of pixels changed. Magenta/colored regions in the diff mark where the PR changed the rendering. Call load_screenshots(["${OUT}/diff.png"]) ONCE to see those regions, then go interact with the areas that changed. (Do NOT load pr.png/stable.png — the diff alone is your guide.)`,
-  `PR title: ${meta.title}`,
-  `PR description: ${redact(meta.body || '(none)').slice(0, 1500)}`,
-  `Changed files: ${(meta.files || []).map((f) => f.path).join(', ').slice(0, 800)}`,
-  `Code diff (truncated, secrets redacted): ${redact(diff).slice(0, 6000)}`,
-  '',
-  'Then interact like a real user: apply a filter, run a search, paginate, open/inspect cards. Use the visual diff + code diff to focus where this PR changed things, and judge whether each change is intended or a regression. Run run_axe and get_console_errors at least once. Report anything broken/truncated/misaligned/low-contrast/wrong; if clean, say so. End with done(report, verdict).',
-].join('\n');
+// Shared change (Card.jsx / Container / Helpers / app / any LESS) -> review all pages.
+const SHARED = /Card\.jsx|Container\.jsx|Helpers\/|app\.jsx|\.less/i;
+const isShared = SHARED.test(changed);
+let selected = isShared ? PAGES : PAGES.filter((p) => p.triggers.test(changed));
+if (selected.length === 0) selected = [PAGES[0]]; // smoke
+console.log(`Selected ${selected.length} page(s): ${selected.map((p) => p.id).join(', ')}`);
 
-const REPORT_OUT = '/tmp/pr-review-report.json';
-try { unlinkSync(REPORT_OUT); } catch {}
-const AGENT_TIMEOUT_MS = Number(env('AGENT_TIMEOUT_MS', '600000')); // hard cap: a hung browser can never block the runner
-const run = spawnSync('node', ['qa-runner-v2.mjs', instruction], {
-  stdio: 'inherit',
-  timeout: AGENT_TIMEOUT_MS,
-  killSignal: 'SIGKILL',
-  env: { ...process.env, DIST_DIR: DIST, REPORT_OUT, MAX_TURNS: env('MAX_TURNS', '14') },
-});
-const timedOut = run.signal === 'SIGKILL' || run.error?.code === 'ETIMEDOUT';
-
-let verdict = 'UNKNOWN', report = timedOut
-  ? `Agent run exceeded the ${Math.round(AGENT_TIMEOUT_MS / 60000)}-minute cap and was stopped; partial exploration only. (${pct}% of pixels changed vs stable.)`
-  : '(agent produced no report)';
-if (existsSync(REPORT_OUT)) {
-  try { const j = JSON.parse(readFileSync(REPORT_OUT, 'utf8')); verdict = j.verdict || verdict; report = j.report || report; } catch {}
+async function captureDiff(url, tag) {
+  let pct = 'n/a';
+  try {
+    const browser = await chromium.connectOverCDP(CDP);
+    const c = browser.contexts()[0] || (await browser.newContext());
+    const shot = async (inject, out) => {
+      const p = await c.newPage(); await p.setViewportSize({ width: 1280, height: 1800 });
+      if (inject) {
+        await p.route('**/caas-libs/**', async (r) => {
+          const f = r.request().url().split('?')[0].split('/').pop();
+          if (!ALLOW.has(f)) return r.continue();
+          try { await r.fulfill({ path: `${DIST}/${f}`, contentType: ct(f) }); } catch { await r.continue(); }
+        });
+      }
+      await p.goto(url, { waitUntil: 'load', timeout: 45000 }).catch(() => {});
+      await p.waitForTimeout(15000);
+      const card = await p.$('.consonant-Card'); if (card) await card.scrollIntoViewIfNeeded().catch(() => {});
+      await p.waitForTimeout(1500); await p.screenshot({ path: out }); await p.close();
+    };
+    await shot(true, `${OUT}/${tag}-pr.png`);
+    await shot(false, `${OUT}/${tag}-stable.png`);
+    await browser.close();
+    const a = PNG.sync.read(readFileSync(`${OUT}/${tag}-pr.png`)), b = PNG.sync.read(readFileSync(`${OUT}/${tag}-stable.png`));
+    const w = Math.min(a.width, b.width), h = Math.min(a.height, b.height);
+    const ca = new PNG({ width: w, height: h }); PNG.bitblt(a, ca, 0, 0, w, h, 0, 0);
+    const cb = new PNG({ width: w, height: h }); PNG.bitblt(b, cb, 0, 0, w, h, 0, 0);
+    const d = new PNG({ width: w, height: h });
+    const n = pixelmatch(ca.data, cb.data, d.data, w, h, { threshold: 0.12, includeAA: false });
+    writeFileSync(`${OUT}/${tag}-diff.png`, PNG.sync.write(d)); pct = (100 * n / (w * h)).toFixed(2);
+  } catch (e) { console.log(`[${tag}] diff capture failed: ${String(e).slice(0, 120)}`); }
+  return pct;
 }
 
+const sections = [];
+for (const page of selected) {
+  console.log(`\n===== ${page.id} :: ${page.url} =====`);
+  const pct = await captureDiff(page.url, page.id);
+  const instruction = [
+    `Target URL: ${page.url}`, '',
+    `You are QA-reviewing pull request #${PR}. The PR's CaaS build is injected into this live page, so you are testing the PR's code on the real page.`,
+    `A pixel diff of the PR build vs current stable was captured; ${pct}% of pixels changed. Magenta regions mark where the PR changed rendering. Call load_screenshots(["${OUT}/${page.id}-diff.png"]) once to see them, then interact.`,
+    `PR title: ${meta.title}`,
+    `Code diff (truncated, secrets redacted): ${redact(diff).slice(0, 5000)}`,
+    '', page.instr, '',
+    'Interact like a real user per the instruction; use the diff to focus where the PR changed things. Report anything broken/truncated/misaligned/wrong; if clean, say so. End with done(report, verdict).',
+  ].join('\n');
+  const REPORT_OUT = `/tmp/pr-review-${page.id}.json`; try { unlinkSync(REPORT_OUT); } catch {}
+  const run = spawnSync('node', ['qa-runner-v2.mjs', instruction], {
+    stdio: 'inherit', timeout: Number(env('AGENT_TIMEOUT_MS', '180000')), killSignal: 'SIGKILL',
+    env: { ...process.env, DIST_DIR: DIST, REPORT_OUT, MAX_TURNS: env('MAX_TURNS', '12') },
+  });
+  const timedOut = run.signal === 'SIGKILL' || run.error?.code === 'ETIMEDOUT';
+  let verdict = 'UNKNOWN', report = timedOut ? `Agent run exceeded the per-page time cap; partial only. (${pct}% pixels changed.)` : '(no report produced)';
+  if (existsSync(REPORT_OUT)) { try { const j = JSON.parse(readFileSync(REPORT_OUT, 'utf8')); verdict = j.verdict || verdict; report = j.report || report; } catch {} }
+  sections.push({ id: page.id, url: page.url, pct, verdict, report });
+}
+
+const overall = sections.some((s) => s.verdict === 'FAIL') ? 'FAIL' : (sections.every((s) => s.verdict === 'PASS') ? 'PASS' : 'MIXED');
 const MARKER = '<!-- agent-qa-review -->';
-const comment = [
-  MARKER,
-  '## 🤖 Agent QA review — interactive + visual diff (advisory, non-blocking)',
+const body = [MARKER,
+  '## 🤖 Agent QA review — multi-page, interactive + visual diff (advisory, non-blocking)',
   '',
-  `Drove the PR build on the live business.adobe.com collection (filtered, searched, paginated, inspected cards), guided by a PR-vs-stable visual diff (**${pct}%** of pixels changed) and the PR code diff. Verdict: **${verdict}**.`,
+  `Reviewed **${sections.length}** page(s) on the live site with the PR build injected. Overall: **${overall}**.`,
   '',
-  report,
+  ...sections.map((s) => `<details><summary><b>${s.verdict}</b> — ${s.id} · ${s.pct}% pixels changed · ${s.url}</summary>\n\n${s.report}\n\n</details>`),
   '',
-  RUN_URL ? `_PR / stable / diff screenshots + console + axe artifacts in the [workflow run](${RUN_URL})._` : '',
+  RUN_URL ? `_Per-page screenshots + diffs in the [workflow run](${RUN_URL})._` : '',
 ].join('\n');
 
-let id = '';
-try {
-  const list = JSON.parse(gh(['pr', 'view', PR, '-R', REPO, '--json', 'comments']));
-  const mine = (list.comments || []).filter((cm) => (cm.body || '').includes(MARKER)).pop();
-  if (mine && mine.url) id = mine.url.split('issuecomment-').pop();
-} catch {}
-if (id) {
-  gh(['api', '-X', 'PATCH', `repos/${REPO}/issues/comments/${id}`, '-f', `body=${comment}`]);
-} else {
-  writeFileSync(`${OUT}/comment.md`, comment);
-  gh(['pr', 'comment', PR, '-R', REPO, '--body-file', `${OUT}/comment.md`]);
-}
-console.log(`agent-review: review posted on PR #${PR} (verdict ${verdict}, diff ${pct}%, timedOut=${timedOut})`);
+let cid = '';
+try { const list = JSON.parse(gh(['pr', 'view', PR, '-R', REPO, '--json', 'comments'])); const m = (list.comments || []).filter((c) => (c.body || '').includes(MARKER)).pop(); if (m && m.url) cid = m.url.split('issuecomment-').pop(); } catch {}
+if (cid) { gh(['api', '-X', 'PATCH', `repos/${REPO}/issues/comments/${cid}`, '-f', `body=${body}`]); }
+else { writeFileSync(`${OUT}/comment.md`, body); gh(['pr', 'comment', PR, '-R', REPO, '--body-file', `${OUT}/comment.md`]); }
+console.log(`agent-review: posted combined review on #${PR} — overall ${overall} across ${sections.length} page(s)`);
 process.exit(0);

--- a/.github/qa/agent-review.mjs
+++ b/.github/qa/agent-review.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /** Multi-page interactive agent QA review (advisory, non-blocking).
  *  For each PR-relevant page: capture a PR-build-vs-stable visual diff
- *  (segmented into bands for very tall pages), drive the interactive
+ *  drive the interactive
  *  qa-runner with a page-specific instruction, post ONE combined comment. */
 import { execFileSync, spawnSync } from 'node:child_process';
 import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from 'node:fs';
@@ -45,9 +45,17 @@ const PAGES = [
     triggers: /Carousel|Grid|Card\.jsx/i,
     instr: `Carousel collection. Cards render in a horizontal carousel. Click next/prev (or scroll) -> the carousel advances and shows new cards. Verify the arrows/affordances render and nothing is clipped or overlapping.` },
   { id: 'E-gallery', url: 'https://milo.adobe.com/drafts/caas/card-styles',
-    triggers: /Cards\/|Card\.jsx|CardContent|CardHeader|CardFooter/i, fullPage: true, segment: true, bandHeight: 1500, wait: 22000,
-    instr: `Card-style gallery: a TALL page rendering every card style. VISUAL review only -- you do NOT need to interact. The full-page diff is split into vertical bands; load the changed bands and report each card style that looks broken: truncated/clipped text, broken/missing image, misaligned or overlapping elements, wrong spacing, or a style that fails to render. If no bands changed, say all styles render cleanly. End with done(report, verdict) promptly.` },
+    triggers: /Cards\/|Card\.jsx|CardContent|CardHeader|CardFooter/i, fullPage: true, wait: 16000,
+    instr: `Card-style gallery: a TALL page rendering every card style. VISUAL review only -- you do NOT need to interact. Load the diff image once (load_screenshots), then report each card style that looks broken: truncated/clipped text, broken/missing image, misaligned or overlapping elements, wrong spacing, or a style that fails to render. If nothing changed, say all styles render cleanly. End with done(report, verdict) promptly.` },
 ];
+
+const SEL = {
+  'A-left-hub':  { cards: '.consonant-Card', count: '.consonant-FiltersInfo-results', filterGroup: '.consonant-LeftFilters-header', filterScope: '.consonant-Filters', filterCheckbox: '.consonant-Filters input[type=checkbox]', clearAll: '.consonant-LeftFilters-clearLink', search: '.consonant-Search-input', sort: '.consonant-Select-btn', pagination: '.consonant-Pagination' },
+  'B-top-panel': { cards: '.consonant-Card', filterOpen: '.consonant-TopFilter-link', filterScope: '.consonant-TopFilter', filterCheckbox: '.consonant-TopFilter input[type=checkbox]', sort: '.consonant-Select-btn', pagination: '.consonant-Pagination' },
+  'C-events':    { cards: '.consonant-Card', filterOpen: '.consonant-TopFilter-link', filterScope: '.consonant-TopFilter', filterCheckbox: '.consonant-TopFilter input[type=checkbox]', pagination: '.consonant-Pagination.lightText' },
+  'D-carousel':  { cards: '.consonant-Card', cardLink: '.consonant-LinkBlocker' },
+  'E-gallery':   { cards: '.consonant-Card' },
+};
 
 const SHARED = /Card\.jsx|Container\.jsx|Helpers\/|app\.jsx|\.less/i;
 const isShared = SHARED.test(changed);
@@ -56,7 +64,7 @@ if (selected.length === 0) selected = [PAGES[0]];
 console.log(`Selected ${selected.length} page(s): ${selected.map((p) => p.id).join(', ')}`);
 
 async function captureDiff(url, tag, opts = {}) {
-  let pct = 'n/a'; const bands = [];
+  let pct = 'n/a';
   try {
     const browser = await chromium.connectOverCDP(CDP);
     const c = browser.contexts()[0] || (await browser.newContext());
@@ -85,50 +93,41 @@ async function captureDiff(url, tag, opts = {}) {
     await browser.close();
     const a = PNG.sync.read(readFileSync(`${OUT}/${tag}-pr.png`)), b = PNG.sync.read(readFileSync(`${OUT}/${tag}-stable.png`));
     const w = Math.min(a.width, b.width), Ht = Math.min(a.height, b.height);
-    if (opts.segment) {
-      const BH = opts.bandHeight || 1500; let changed2 = 0;
-      for (let y = 0, i = 0; y < Ht; y += BH, i++) {
-        const bh = Math.min(BH, Ht - y);
-        const pa = new PNG({ width: w, height: bh }); PNG.bitblt(a, pa, 0, y, w, bh, 0, 0);
-        const pb = new PNG({ width: w, height: bh }); PNG.bitblt(b, pb, 0, y, w, bh, 0, 0);
-        const pd = new PNG({ width: w, height: bh });
-        const n = pixelmatch(pa.data, pb.data, pd.data, w, bh, { threshold: 0.12, includeAA: false });
-        changed2 += n;
-        const bp = 100 * n / (w * bh);
-        if (bp > 0.3) { const fp = `${OUT}/${tag}-band${i}-diff.png`; writeFileSync(fp, PNG.sync.write(pd)); bands.push({ i, pct: bp.toFixed(2), path: fp }); }
-      }
-      pct = (100 * changed2 / (w * Ht)).toFixed(2);
-    } else {
-      const ca = new PNG({ width: w, height: Ht }); PNG.bitblt(a, ca, 0, 0, w, Ht, 0, 0);
-      const cb = new PNG({ width: w, height: Ht }); PNG.bitblt(b, cb, 0, 0, w, Ht, 0, 0);
-      const d = new PNG({ width: w, height: Ht });
-      const n = pixelmatch(ca.data, cb.data, d.data, w, Ht, { threshold: 0.12, includeAA: false });
-      writeFileSync(`${OUT}/${tag}-diff.png`, PNG.sync.write(d)); pct = (100 * n / (w * Ht)).toFixed(2);
-    }
+    const ca = new PNG({ width: w, height: Ht }); PNG.bitblt(a, ca, 0, 0, w, Ht, 0, 0);
+    const cb = new PNG({ width: w, height: Ht }); PNG.bitblt(b, cb, 0, 0, w, Ht, 0, 0);
+    const d = new PNG({ width: w, height: Ht });
+    const n = pixelmatch(ca.data, cb.data, d.data, w, Ht, { threshold: 0.12, includeAA: false });
+    writeFileSync(`${OUT}/${tag}-diff.png`, PNG.sync.write(d)); pct = (100 * n / (w * Ht)).toFixed(2);
   } catch (e) { console.log(`[${tag}] diff capture failed: ${String(e).slice(0, 120)}`); }
-  return { pct, bands };
+  return { pct };
 }
 
 const sections = [];
 for (const page of selected) {
   console.log(`\n===== ${page.id} :: ${page.url} =====`);
-  const { pct, bands } = await captureDiff(page.url, page.id, { fullPage: page.fullPage, wait: page.wait, segment: page.segment, bandHeight: page.bandHeight });
-  const diffHint = bands.length
-    ? `The full-page pixel diff was split into vertical bands (this page is very tall); overall ${pct}% changed, ${bands.length} band(s) changed. Load them: load_screenshots([${bands.map((bb) => `"${bb.path}"`).join(', ')}]). NOTE: a change to a card's height (e.g. a truncated title) shifts every card BELOW it upward, so several changed bands can be ONE root cause -- report the root cause(s), not each shifted band.`
-    : `A pixel diff of the PR build vs current stable was captured; ${pct}% of pixels changed. Magenta regions mark where the PR changed rendering. Call load_screenshots(["${OUT}/${page.id}-diff.png"]) once to see them, then interact.`;
+  const { pct } = await captureDiff(page.url, page.id, { fullPage: page.fullPage, wait: page.wait });
+  const diffHint = `A pixel diff of the PR build vs current stable was captured; ${pct}% of pixels changed. Magenta regions mark where the PR changed rendering. Call load_screenshots(["${OUT}/${page.id}-diff.png"]) once to see them, then interact.`;
+  const sel = SEL[page.id] || {};
+  const selHint = Object.keys(sel).length
+    ? ['Selectors for THIS page. To interact efficiently: call get_interactives(scope) SCOPED to the container below (returns a SMALL numbered list), then click the ref -- do NOT call get_interactives unscoped, which dumps the whole page and wastes turns. Use find_and_show(selector) to bring a region into view first.',
+       ...Object.entries(sel).map(([k, v]) => '  - ' + k + ': ' + v),
+       sel.count ? 'Read the live result count from "' + sel.count + '" via evaluate after each interaction.'
+                 : 'No count element here; measure result size by counting "' + (sel.cards || '.consonant-Card') + '" via evaluate(document.querySelectorAll(...).length).',
+      ].join('\n')
+    : '';
   const instruction = [
     `Target URL: ${page.url}`, '',
     `You are QA-reviewing pull request #${PR}. The PR's CaaS build is injected into this live page, so you are testing the PR's code on the real page.`,
     diffHint,
     `PR title: ${meta.title}`,
     `Code diff (truncated, secrets redacted): ${redact(diff).slice(0, 5000)}`,
-    '', page.instr, '',
+    '', selHint, '', page.instr, '',
     'Report anything broken/truncated/misaligned/wrong; if clean, say so. End with done(report, verdict).',
   ].join('\n');
   const REPORT_OUT = `/tmp/pr-review-${page.id}.json`; try { unlinkSync(REPORT_OUT); } catch {}
   const run = spawnSync('node', ['qa-runner-v2.mjs', instruction], {
-    stdio: 'inherit', timeout: Number(env('AGENT_TIMEOUT_MS', '180000')), killSignal: 'SIGKILL',
-    env: { ...process.env, DIST_DIR: DIST, REPORT_OUT, MAX_TURNS: env('MAX_TURNS', '16') },
+    stdio: 'inherit', timeout: Number(env('AGENT_TIMEOUT_MS', '120000')), killSignal: 'SIGKILL',
+    env: { ...process.env, DIST_DIR: DIST, REPORT_OUT, MAX_TURNS: env('MAX_TURNS', '10') },
   });
   const timedOut = run.signal === 'SIGKILL' || run.error?.code === 'ETIMEDOUT';
   let verdict = 'UNKNOWN', report = timedOut ? `Agent run exceeded the per-page time cap; partial only. (${pct}% pixels changed.)` : '(no report produced)';

--- a/.github/qa/agent-review.mjs
+++ b/.github/qa/agent-review.mjs
@@ -46,8 +46,8 @@ const PAGES = [
     triggers: /Carousel|Grid|Card\.jsx/i,
     instr: `Carousel collection. Cards render in a horizontal carousel. Click next/prev (or scroll) -> the carousel advances and shows new cards. Verify the arrows/affordances render and nothing is clipped or overlapping.` },
   { id: 'E-gallery', url: 'https://milo.adobe.com/drafts/caas/card-styles',
-    triggers: /Cards\/|Card\.jsx|CardContent|CardHeader|CardFooter/i,
-    instr: `Card-style gallery: every card style is rendered on one page. VISUAL review -- scan all styles for rendering regressions: truncated/clipped text, broken or missing images, misaligned/overlapping elements, wrong spacing, a style that fails to render. Use the visual diff to focus where the PR changed rendering.` },
+    triggers: /Cards\/|Card\.jsx|CardContent|CardHeader|CardFooter/i, fullPage: true, wait: 22000,
+    instr: `Card-style gallery: a TALL page rendering every card style. VISUAL review only -- you do NOT need to interact. A full-page PR-vs-stable pixel diff was captured. Load the diff, find the magenta regions (where rendering changed), and report each card style that looks broken: truncated/clipped text, broken/missing image, misaligned or overlapping elements, wrong spacing, or a style that fails to render. If the diff is essentially empty, say all styles render cleanly. End with done(report, verdict) promptly.` },
 ];
 
 // Shared change (Card.jsx / Container / Helpers / app / any LESS) -> review all pages.
@@ -57,7 +57,7 @@ let selected = isShared ? PAGES : PAGES.filter((p) => p.triggers.test(changed));
 if (selected.length === 0) selected = [PAGES[0]]; // smoke
 console.log(`Selected ${selected.length} page(s): ${selected.map((p) => p.id).join(', ')}`);
 
-async function captureDiff(url, tag) {
+async function captureDiff(url, tag, opts = {}) {
   let pct = 'n/a';
   try {
     const browser = await chromium.connectOverCDP(CDP);
@@ -72,9 +72,9 @@ async function captureDiff(url, tag) {
         });
       }
       await p.goto(url, { waitUntil: 'load', timeout: 45000 }).catch(() => {});
-      await p.waitForTimeout(15000);
+      await p.waitForTimeout(opts.wait || 15000);
       const card = await p.$('.consonant-Card'); if (card) await card.scrollIntoViewIfNeeded().catch(() => {});
-      await p.waitForTimeout(1500); await p.screenshot({ path: out }); await p.close();
+      await p.waitForTimeout(1500); await p.screenshot({ path: out, fullPage: !!opts.fullPage }); await p.close();
     };
     await shot(true, `${OUT}/${tag}-pr.png`);
     await shot(false, `${OUT}/${tag}-stable.png`);
@@ -93,7 +93,7 @@ async function captureDiff(url, tag) {
 const sections = [];
 for (const page of selected) {
   console.log(`\n===== ${page.id} :: ${page.url} =====`);
-  const pct = await captureDiff(page.url, page.id);
+  const pct = await captureDiff(page.url, page.id, { fullPage: page.fullPage, wait: page.wait });
   const instruction = [
     `Target URL: ${page.url}`, '',
     `You are QA-reviewing pull request #${PR}. The PR's CaaS build is injected into this live page, so you are testing the PR's code on the real page.`,
@@ -106,7 +106,7 @@ for (const page of selected) {
   const REPORT_OUT = `/tmp/pr-review-${page.id}.json`; try { unlinkSync(REPORT_OUT); } catch {}
   const run = spawnSync('node', ['qa-runner-v2.mjs', instruction], {
     stdio: 'inherit', timeout: Number(env('AGENT_TIMEOUT_MS', '180000')), killSignal: 'SIGKILL',
-    env: { ...process.env, DIST_DIR: DIST, REPORT_OUT, MAX_TURNS: env('MAX_TURNS', '12') },
+    env: { ...process.env, DIST_DIR: DIST, REPORT_OUT, MAX_TURNS: env('MAX_TURNS', '18') },
   });
   const timedOut = run.signal === 'SIGKILL' || run.error?.code === 'ETIMEDOUT';
   let verdict = 'UNKNOWN', report = timedOut ? `Agent run exceeded the per-page time cap; partial only. (${pct}% pixels changed.)` : '(no report produced)';

--- a/.github/workflows/qa-agent-review.yml
+++ b/.github/workflows/qa-agent-review.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   agent-review:
     runs-on: [self-hosted, qa-audit]   # the Mini — only runner with the persistent Chrome/CDP
-    timeout-minutes: 20
+    timeout-minutes: 30
     # Same-repo PRs only (public repo + self-hosted runner); manual dispatch always allowed.
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:


### PR DESCRIPTION
Upgrades the agent QA review from a single hardcoded URL to a validated 5-page covering set, each exercising distinct CaaS code paths, with one combined comment.

- **A** customer-success-stories (Left filter, OR semantics, search/sort/deep-link/bookmarks/chips/no-results)
- **B** news.adobe.com (Top filter panel)
- **C** adobe.com/events (event ordering + register/gating banner)
- **D** adobe.com/max community (carousel)
- **E** milo card-styles gallery (visual diff of all card styles)

PR-aware routing: a shared change (Card.jsx / Container / Helpers / any LESS) reviews all pages; a localized change reviews only the pages whose code paths it touches; a .github-only change runs a single smoke page. OR-filter semantics are encoded in the page A/B instructions so the agent does not flag the union-widening as a bug. a11y interaction checks deferred to a later iteration. Per-page agent time-capped; job timeout raised to 30 min.