### PR TITLE
test(mwpw-184989): seed regressions to validate multi-page agent

### DIFF
--- a/.github/qa/agent-review.mjs
+++ b/.github/qa/agent-review.mjs
@@ -125,6 +125,7 @@ for (const page of selected) {
     ? [
         `Target URL: ${page.url}`, '',
         `You are QA-reviewing pull request #${PR}. The PR's CaaS build is injected into this live page.`,
+        `Files the PR touched (use ONLY to decide which components to look at closely -- your verdict must rest on what you actually SEE broken, NOT on the filenames):\n${changed}`,
         diffHint,
         '', page.instr, '',
       ]

--- a/.github/qa/agent-review.mjs
+++ b/.github/qa/agent-review.mjs
@@ -35,14 +35,15 @@ const PAGES = [
   { id: 'A-left-hub', url: 'https://business.adobe.com/customer-success-stories.html',
     triggers: /Filters\/Left|CardFilterer|getFilteredCards|Helpers|Search|Sort|Pagination|Bookmark|Container|Card\.jsx/i,
     kind: 'interactive',
-    instr: `OR-filter assertion. Budget: 8 turns, then call done IMMEDIATELY. This is a left-filter collection that uses OR within a group.
-STEP A (1 turn): navigate to the URL. evaluate({code: JSON.stringify({count: document.querySelector('.consonant-FiltersInfo-results')?.textContent || null, cards: document.querySelectorAll('.consonant-Card').length})}). Record the baseline (e.g. "344 results", 12 cards).
-STEP B (2 turns): find_and_show ".consonant-LeftFilters-header" to reveal the filter panel. get_interactives scope ".consonant-Filters" (a small list). click the FIRST filter checkbox; note its label.
-STEP C (1 turn): re-run the STEP A evaluate. A correct build NARROWS to a NON-ZERO count (fewer than baseline, greater than 0) and re-renders cards. Zero or "No results" after one normal filter is THE BUG.
-STEP D (2 turns): get_interactives scope ".consonant-Filters"; click a SECOND checkbox in the same group. re-run the evaluate. With OR within a group the result should WIDEN (union, at least the single-filter count) -- treat an increase as CORRECT, not a bug.
-STEP E (1 turn): done(report, verdict).
-VERDICT: PASS only if one filter yields a NON-ZERO narrowed count AND the second filter widens it. FAIL if one filter yields ZERO / "No results" (filtering broken) or the count never changes when filters are applied.
-REPORT: state the baseline count, the count after one filter, and after two filters, then the explicit reason for the verdict.` },
+    instr: `OR-filter assertion. Budget: 10 turns, then call done IMMEDIATELY. This is a DOM/count assertion -- NEVER call take_screenshot or find_and_show; drive it only with get_interactives, click, and evaluate. The left filter is TWO-LEVEL: filter checkboxes are hidden until you expand a group (Products / Content Type / Industry), so you must expand a group first.
+STEP A: navigate to the URL. evaluate({code: JSON.stringify({count: document.querySelector('.consonant-FiltersInfo-results')?.textContent || null})}). Record the baseline (e.g. "344 results").
+STEP B: get_interactives scope ".consonant-LeftFilter". click the FIRST group header (e.g. "Products" or "Industry") to expand it.
+STEP C: get_interactives scope ".consonant-LeftFilter" again (checkboxes are now listed). click the FIRST checkbox; note its label.
+STEP D: evaluate the same count expression. A correct build NARROWS to a NON-ZERO number (less than baseline, greater than 0). Zero or "No results" after one normal filter is THE BUG.
+STEP E: click a SECOND checkbox in the same group (already in the list). evaluate the count again. With OR the result should WIDEN (union, at least the single-filter count) -- an increase is CORRECT.
+STEP F: done(report, verdict).
+VERDICT: PASS only if one filter yields a NON-ZERO narrowed count AND the second widens it. FAIL if one filter yields ZERO / "No results" (filtering broken) or the count never changes.
+REPORT: state the baseline count, the count after one filter, and after two filters, then the explicit reason.` },
   { id: 'B-top-panel', url: 'https://news.adobe.com/news?ch_News+articles=Experience%2520Cloud',
     triggers: /Filters\/Top|Container|CardFilterer|getFilteredCards|Helpers|Card\.jsx/i,
     instr: `Top-filter collection (a filter is pre-applied via the URL). Confirm the page loads already filtered to that selection. Open the top filter bar, change/add a filter -> results and count update. ${OR} Run a search -> results update.` },
@@ -68,7 +69,7 @@ const SEL = {
 const SHARED = /Card\.jsx|Container\.jsx|Helpers\/|app\.jsx|\.less/i;
 const isShared = SHARED.test(changed);
 let selected = isShared ? PAGES : PAGES.filter((p) => p.triggers.test(changed));
-if (selected.length === 0) selected = [PAGES[0]];
+selected = [PAGES[0]]; // TEMP: single-page validation (revert before scaling)
 console.log(`Selected ${selected.length} page(s): ${selected.map((p) => p.id).join(', ')}`);
 
 async function captureDiff(url, tag, opts = {}) {

--- a/.github/qa/agent-review.mjs
+++ b/.github/qa/agent-review.mjs
@@ -31,22 +31,19 @@ let diff = ''; try { diff = gh(['pr', 'diff', PR, '-R', REPO]); } catch {}
 const changed = (meta.files || []).map((f) => f.path).join('\n');
 
 const OR = 'This collection uses OR filtering: selecting one filter narrows the full set, but selecting a SECOND filter in the same group WIDENS the results (union) -- treat that increase as CORRECT, not a bug.';
+const VISUAL = `Loose VISUAL review. Budget: 6 turns, then call done(). Automated e2e tests already cover exact counts, filtering and sort order -- your ONLY job is to catch things that LOOK broken on the rendered page.
+STEP 1: Load the captured PR-vs-stable diff (load_screenshots on the path given above). Magenta marks where the PR changed rendering. Judge whether any change looks like a REGRESSION -- truncated/clipped text, a broken/missing/distorted image, overlapping or misaligned cards, wrong spacing, or low contrast -- versus a benign or intended change.
+STEP 2 (optional, 1-2 turns): if a region looks worth checking in an interacted state, open the filter panel or apply one filter (get_interactives scoped to the filter, then click) and take_screenshot -- does the result render cleanly or fall apart? Do NOT verify counts, just look.
+STEP 3: get_console_errors -- note any crash.
+STEP 4: done(report, verdict). PASS = nothing looks broken. FAIL = say exactly what looks broken and where. Judge ONLY by what you SEE, not by the code.`;
+
 const PAGES = [
   { id: 'A-left-hub', url: 'https://business.adobe.com/customer-success-stories.html',
     triggers: /Filters\/Left|CardFilterer|getFilteredCards|Helpers|Search|Sort|Pagination|Bookmark|Container|Card\.jsx/i,
-    kind: 'interactive',
-    instr: `OR-filter assertion. Budget: 10 turns, then call done IMMEDIATELY. This is a DOM/count assertion -- NEVER call take_screenshot or find_and_show; drive it only with get_interactives, click, and evaluate. The left filter is TWO-LEVEL: filter checkboxes are hidden until you expand a group (Products / Content Type / Industry), so you must expand a group first.
-STEP A: navigate to the URL. evaluate({code: JSON.stringify({count: document.querySelector('.consonant-FiltersInfo-results')?.textContent || null})}). Record the baseline (e.g. "344 results").
-STEP B: get_interactives scope ".consonant-LeftFilter". click the FIRST group header (e.g. "Products" or "Industry") to expand it.
-STEP C: get_interactives scope ".consonant-LeftFilter" again (checkboxes are now listed). click the FIRST checkbox; note its label.
-STEP D: evaluate the same count expression. A correct build NARROWS to a NON-ZERO number (less than baseline, greater than 0). Zero or "No results" after one normal filter is THE BUG.
-STEP E: click a SECOND checkbox in the same group (already in the list). evaluate the count again. With OR the result should WIDEN (union, at least the single-filter count) -- an increase is CORRECT.
-STEP F: done(report, verdict).
-VERDICT: PASS only if one filter yields a NON-ZERO narrowed count AND the second widens it. FAIL if one filter yields ZERO / "No results" (filtering broken) or the count never changes.
-REPORT: state the baseline count, the count after one filter, and after two filters, then the explicit reason.` },
+    kind: 'visual', instr: VISUAL },
   { id: 'B-top-panel', url: 'https://news.adobe.com/news?ch_News+articles=Experience%2520Cloud',
     triggers: /Filters\/Top|Container|CardFilterer|getFilteredCards|Helpers|Card\.jsx/i,
-    instr: `Top-filter collection (a filter is pre-applied via the URL). Confirm the page loads already filtered to that selection. Open the top filter bar, change/add a filter -> results and count update. ${OR} Run a search -> results update.` },
+    kind: 'visual', instr: VISUAL },
   { id: 'C-events', url: 'https://www.adobe.com/events.html',
     triggers: /eventSort|Sort|timing|event|Container|Helpers|Card\.jsx/i,
     instr: `Event collection (cards have dates). Verify the ordering looks right for events (upcoming first / dates ascending, not past-first). Check a register / save-your-spot banner card -> its CTA renders and is clickable. Apply a filter if present -> results update.` },
@@ -69,7 +66,7 @@ const SEL = {
 const SHARED = /Card\.jsx|Container\.jsx|Helpers\/|app\.jsx|\.less/i;
 const isShared = SHARED.test(changed);
 let selected = isShared ? PAGES : PAGES.filter((p) => p.triggers.test(changed));
-selected = [PAGES[0]]; // TEMP: single-page validation (revert before scaling)
+selected = PAGES.filter((p) => p.id === 'A-left-hub' || p.id === 'B-top-panel'); // TEMP: validate A+B loose-visual
 console.log(`Selected ${selected.length} page(s): ${selected.map((p) => p.id).join(', ')}`);
 
 async function captureDiff(url, tag, opts = {}) {
@@ -124,7 +121,14 @@ for (const page of selected) {
                  : 'No count element here; measure result size by counting "' + (sel.cards || '.consonant-Card') + '" via evaluate(document.querySelectorAll(...).length).',
       ].join('\n')
     : '';
-  const instruction = (page.kind === 'interactive'
+  const instruction = (page.kind === 'visual'
+    ? [
+        `Target URL: ${page.url}`, '',
+        `You are QA-reviewing pull request #${PR}. The PR's CaaS build is injected into this live page.`,
+        diffHint,
+        '', page.instr, '',
+      ]
+    : page.kind === 'interactive'
     ? [
         `Target URL: ${page.url}`, '',
         `You are QA-reviewing pull request #${PR}. The PR's CaaS build is injected into this live page, so you are testing the PR's real code.`,

--- a/.github/qa/agent-review.mjs
+++ b/.github/qa/agent-review.mjs
@@ -34,7 +34,15 @@ const OR = 'This collection uses OR filtering: selecting one filter narrows the 
 const PAGES = [
   { id: 'A-left-hub', url: 'https://business.adobe.com/customer-success-stories.html',
     triggers: /Filters\/Left|CardFilterer|getFilteredCards|Helpers|Search|Sort|Pagination|Bookmark|Container|Card\.jsx/i,
-    instr: `Left-filter collection. ${OR} Open the left filter panel, select a filter -> results narrow, the count updates, a selected-filter chip appears. Add a second filter in the same group -> results WIDEN (OR). Clear All -> back to full. Pick a filter combination yielding nothing -> a no-results empty state shows (not a blank/broken grid). Search a query -> results filter and the matched term is highlighted. Change the Sort dropdown -> the visible order changes. Go to page 2 -> the URL gains page=2 and different cards show; navigate to that page-2 URL fresh -> it should restore page 2. Bookmark a card -> the icon toggles; open the saved view -> only saved cards show. Click a card -> opens the expected link/modal.` },
+    kind: 'interactive',
+    instr: `OR-filter assertion. Budget: 8 turns, then call done IMMEDIATELY. This is a left-filter collection that uses OR within a group.
+STEP A (1 turn): navigate to the URL. evaluate({code: JSON.stringify({count: document.querySelector('.consonant-FiltersInfo-results')?.textContent || null, cards: document.querySelectorAll('.consonant-Card').length})}). Record the baseline (e.g. "344 results", 12 cards).
+STEP B (2 turns): find_and_show ".consonant-LeftFilters-header" to reveal the filter panel. get_interactives scope ".consonant-Filters" (a small list). click the FIRST filter checkbox; note its label.
+STEP C (1 turn): re-run the STEP A evaluate. A correct build NARROWS to a NON-ZERO count (fewer than baseline, greater than 0) and re-renders cards. Zero or "No results" after one normal filter is THE BUG.
+STEP D (2 turns): get_interactives scope ".consonant-Filters"; click a SECOND checkbox in the same group. re-run the evaluate. With OR within a group the result should WIDEN (union, at least the single-filter count) -- treat an increase as CORRECT, not a bug.
+STEP E (1 turn): done(report, verdict).
+VERDICT: PASS only if one filter yields a NON-ZERO narrowed count AND the second filter widens it. FAIL if one filter yields ZERO / "No results" (filtering broken) or the count never changes when filters are applied.
+REPORT: state the baseline count, the count after one filter, and after two filters, then the explicit reason for the verdict.` },
   { id: 'B-top-panel', url: 'https://news.adobe.com/news?ch_News+articles=Experience%2520Cloud',
     triggers: /Filters\/Top|Container|CardFilterer|getFilteredCards|Helpers|Card\.jsx/i,
     instr: `Top-filter collection (a filter is pre-applied via the URL). Confirm the page loads already filtered to that selection. Open the top filter bar, change/add a filter -> results and count update. ${OR} Run a search -> results update.` },
@@ -115,15 +123,22 @@ for (const page of selected) {
                  : 'No count element here; measure result size by counting "' + (sel.cards || '.consonant-Card') + '" via evaluate(document.querySelectorAll(...).length).',
       ].join('\n')
     : '';
-  const instruction = [
-    `Target URL: ${page.url}`, '',
-    `You are QA-reviewing pull request #${PR}. The PR's CaaS build is injected into this live page, so you are testing the PR's code on the real page.`,
-    diffHint,
-    `PR title: ${meta.title}`,
-    `Code diff (truncated, secrets redacted): ${redact(diff).slice(0, 5000)}`,
-    '', selHint, '', page.instr, '',
-    'Report anything broken/truncated/misaligned/wrong; if clean, say so. End with done(report, verdict).',
-  ].join('\n');
+  const instruction = (page.kind === 'interactive'
+    ? [
+        `Target URL: ${page.url}`, '',
+        `You are QA-reviewing pull request #${PR}. The PR's CaaS build is injected into this live page, so you are testing the PR's real code.`,
+        '', page.instr, '',
+        'Base your verdict ONLY on what you observe by following the steps -- do NOT infer it from any code change. End with done(report, verdict).',
+      ]
+    : [
+        `Target URL: ${page.url}`, '',
+        `You are QA-reviewing pull request #${PR}. The PR's CaaS build is injected into this live page, so you are testing the PR's code on the real page.`,
+        diffHint,
+        `PR title: ${meta.title}`,
+        `Code diff (truncated, secrets redacted): ${redact(diff).slice(0, 5000)}`,
+        '', selHint, '', page.instr, '',
+        'Report anything broken/truncated/misaligned/wrong; if clean, say so. End with done(report, verdict).',
+      ]).join('\n');
   const REPORT_OUT = `/tmp/pr-review-${page.id}.json`; try { unlinkSync(REPORT_OUT); } catch {}
   const run = spawnSync('node', ['qa-runner-v2.mjs', instruction], {
     stdio: 'inherit', timeout: Number(env('AGENT_TIMEOUT_MS', '120000')), killSignal: 'SIGKILL',

--- a/.github/qa/agent-review.mjs
+++ b/.github/qa/agent-review.mjs
@@ -124,7 +124,7 @@ for (const page of selected) {
     ? [
         `Target URL: ${page.url}`, '',
         `You are QA-reviewing pull request #${PR}. The PR's CaaS build is injected into this live page.`,
-        `PR code diff (CONTEXT ONLY -- use it to know which components to scrutinise and to EXPLAIN the cause of anything you SEE broken. Do NOT fail a page merely because code changed; only FAIL if you actually SEE a defect in the render):\n${redact(diff).slice(0, 6000)}`,
+        `Files the PR touched (use ONLY to decide which components to look at closely -- your verdict must rest on what you actually SEE broken, NOT on the filenames):\n${changed}`,
         diffHint,
         '', page.instr, '',
       ]

--- a/.github/qa/agent-review.mjs
+++ b/.github/qa/agent-review.mjs
@@ -31,10 +31,11 @@ let diff = ''; try { diff = gh(['pr', 'diff', PR, '-R', REPO]); } catch {}
 const changed = (meta.files || []).map((f) => f.path).join('\n');
 
 const OR = 'This collection uses OR filtering: selecting one filter narrows the full set, but selecting a SECOND filter in the same group WIDENS the results (union) -- treat that increase as CORRECT, not a bug.';
-const VISUAL = `Loose VISUAL review. Budget: 4 turns, then call done(). Automated e2e tests already cover exact counts, filtering and sort order -- your ONLY job is to catch things that LOOK broken on the rendered page. Do NOT navigate or interact; the captured diff is all you need.
-STEP 1: load_screenshots on the diff path given above. Magenta marks where the PR changed rendering. BOTH screenshots are the SAME page captured seconds apart, so the underlying content is IDENTICAL -- every magenta region is caused by the PR's code, NOT by content rotation or feed churn. Do NOT explain a diff away as 'different articles' or 'content churn'; that is not possible here. Use the PR code diff above to know which components to scrutinise and to name the likely cause, then judge whether the change is a REGRESSION -- truncated/clipped text, a broken/missing/distorted image, overlapping or misaligned cards, wrong spacing, low contrast, or a changed/empty result set.
-STEP 2: get_console_errors -- note any crash.
-STEP 3: done(report, verdict). PASS only if the touched components render correctly. FAIL if you see any visible change in them -- say exactly what and where. Judge ONLY by what you SEE.`;
+const VISUAL = `Loose VISUAL review. Budget: 8 turns, then call done(). Automated e2e tests already cover exact counts/filtering/sort -- your job is to catch things that LOOK broken.
+STEP 1: load_screenshots on the captured PR-vs-stable diff (path above). Magenta = where the PR changed the render. BOTH shots are the SAME page seconds apart, so any diff is from the PR's code, NOT content churn. Use the PR code diff above to know which components to scrutinise and to name the likely cause.
+STEP 2: navigate to the page and SCROLL through it top-to-bottom (take_screenshot / find_and_show) to inspect the components the diff flagged. CRITICAL: CaaS cards LAZY-LOAD -- after navigating, WAIT for the card grid to finish rendering before judging. If the grid looks blank or half-painted, wait and re-screenshot; do NOT report content as missing/broken until the page has clearly finished loading (a blank first paint is normal, not a bug).
+STEP 3: get_console_errors -- note any crash.
+STEP 4: done(report, verdict). PASS if the touched components render correctly once loaded. FAIL only if you SEE a real defect (truncated/clipped text, broken/missing/distorted image, overlapping or misaligned cards, wrong spacing, low contrast, or an empty/broken grid that persists after load). Judge by what you SEE.`;
 
 const PAGES = [
   { id: 'A-left-hub', url: 'https://business.adobe.com/customer-success-stories.html',
@@ -147,7 +148,7 @@ for (const page of selected) {
   const REPORT_OUT = `/tmp/pr-review-${page.id}.json`; try { unlinkSync(REPORT_OUT); } catch {}
   const run = spawnSync('node', ['qa-runner-v2.mjs', instruction], {
     stdio: 'inherit', timeout: Number(env('AGENT_TIMEOUT_MS', '150000')), killSignal: 'SIGKILL',
-    env: { ...process.env, DIST_DIR: DIST, REPORT_OUT, MAX_TURNS: env('MAX_TURNS', '10'), ...(page.kind === 'visual' ? { TOOLS_ALLOW: 'load_screenshots,get_console_errors,done' } : {}) },
+    env: { ...process.env, DIST_DIR: DIST, REPORT_OUT, MAX_TURNS: env('MAX_TURNS', '10') },
   });
   const timedOut = run.signal === 'SIGKILL' || run.error?.code === 'ETIMEDOUT';
   let verdict = 'UNKNOWN', report = timedOut ? `Agent run exceeded the per-page time cap; partial only. (${pct}% pixels changed.)` : '(no report produced)';

--- a/.github/qa/agent-review.mjs
+++ b/.github/qa/agent-review.mjs
@@ -32,9 +32,9 @@ const changed = (meta.files || []).map((f) => f.path).join('\n');
 
 const OR = 'This collection uses OR filtering: selecting one filter narrows the full set, but selecting a SECOND filter in the same group WIDENS the results (union) -- treat that increase as CORRECT, not a bug.';
 const VISUAL = `Loose VISUAL review. Budget: 4 turns, then call done(). Automated e2e tests already cover exact counts, filtering and sort order -- your ONLY job is to catch things that LOOK broken on the rendered page. Do NOT navigate or interact; the captured diff is all you need.
-STEP 1: load_screenshots on the diff path given above. Magenta marks where the PR changed rendering. Use the "files the PR touched" hint to know WHICH components to scrutinise, then judge whether any change is a REGRESSION -- truncated/clipped text, a broken/missing/distorted image, overlapping or misaligned cards, wrong spacing, or low contrast. IMPORTANT: a live feed (e.g. news) rotates its articles/dates between the two screenshots, so a large diff can be mostly harmless CONTENT churn -- look specifically at the components the PR touched to separate a real style regression from that churn.
+STEP 1: load_screenshots on the diff path given above. Magenta marks where the PR changed rendering. BOTH screenshots are the SAME page captured seconds apart, so the underlying content is IDENTICAL -- every magenta region is caused by the PR's code, NOT by content rotation or feed churn. Do NOT explain a diff away as 'different articles' or 'content churn'; that is not possible here. Use the "files the PR touched" hint to know which components to scrutinise, then judge whether the change is a REGRESSION -- truncated/clipped text, a broken/missing/distorted image, overlapping or misaligned cards, wrong spacing, low contrast, or a changed/empty result set.
 STEP 2: get_console_errors -- note any crash.
-STEP 3: done(report, verdict). PASS = nothing looks broken. FAIL = say exactly what looks broken and where. Judge ONLY by what you SEE.`;
+STEP 3: done(report, verdict). PASS only if the touched components render correctly. FAIL if you see any visible change in them -- say exactly what and where. Judge ONLY by what you SEE.`;
 
 const PAGES = [
   { id: 'A-left-hub', url: 'https://business.adobe.com/customer-success-stories.html',

--- a/.github/qa/agent-review.mjs
+++ b/.github/qa/agent-review.mjs
@@ -124,7 +124,7 @@ for (const page of selected) {
     ? [
         `Target URL: ${page.url}`, '',
         `You are QA-reviewing pull request #${PR}. The PR's CaaS build is injected into this live page.`,
-        `Files the PR touched (use ONLY to decide which components to look at closely -- your verdict must rest on what you actually SEE broken, NOT on the filenames):\n${changed}`,
+        `PR code diff (CONTEXT ONLY -- use it to know which components to scrutinise and to EXPLAIN the cause of anything you SEE broken. Do NOT fail a page merely because code changed; only FAIL if you actually SEE a defect in the render):\n${redact(diff).slice(0, 6000)}`,
         diffHint,
         '', page.instr, '',
       ]

--- a/.github/qa/agent-review.mjs
+++ b/.github/qa/agent-review.mjs
@@ -32,7 +32,7 @@ const changed = (meta.files || []).map((f) => f.path).join('\n');
 
 const OR = 'This collection uses OR filtering: selecting one filter narrows the full set, but selecting a SECOND filter in the same group WIDENS the results (union) -- treat that increase as CORRECT, not a bug.';
 const VISUAL = `Loose VISUAL review. Budget: 4 turns, then call done(). Automated e2e tests already cover exact counts, filtering and sort order -- your ONLY job is to catch things that LOOK broken on the rendered page. Do NOT navigate or interact; the captured diff is all you need.
-STEP 1: load_screenshots on the diff path given above. Magenta marks where the PR changed rendering. BOTH screenshots are the SAME page captured seconds apart, so the underlying content is IDENTICAL -- every magenta region is caused by the PR's code, NOT by content rotation or feed churn. Do NOT explain a diff away as 'different articles' or 'content churn'; that is not possible here. Use the "files the PR touched" hint to know which components to scrutinise, then judge whether the change is a REGRESSION -- truncated/clipped text, a broken/missing/distorted image, overlapping or misaligned cards, wrong spacing, low contrast, or a changed/empty result set.
+STEP 1: load_screenshots on the diff path given above. Magenta marks where the PR changed rendering. BOTH screenshots are the SAME page captured seconds apart, so the underlying content is IDENTICAL -- every magenta region is caused by the PR's code, NOT by content rotation or feed churn. Do NOT explain a diff away as 'different articles' or 'content churn'; that is not possible here. Use the PR code diff above to know which components to scrutinise and to name the likely cause, then judge whether the change is a REGRESSION -- truncated/clipped text, a broken/missing/distorted image, overlapping or misaligned cards, wrong spacing, low contrast, or a changed/empty result set.
 STEP 2: get_console_errors -- note any crash.
 STEP 3: done(report, verdict). PASS only if the touched components render correctly. FAIL if you see any visible change in them -- say exactly what and where. Judge ONLY by what you SEE.`;
 
@@ -124,7 +124,7 @@ for (const page of selected) {
     ? [
         `Target URL: ${page.url}`, '',
         `You are QA-reviewing pull request #${PR}. The PR's CaaS build is injected into this live page.`,
-        `Files the PR touched (use ONLY to decide which components to look at closely -- your verdict must rest on what you actually SEE broken, NOT on the filenames):\n${changed}`,
+        `PR code diff (you canNOT navigate -- use this only to INTERPRET the captured diff image and name the likely cause of anything you SEE broken; a Helpers/filter change can EMPTY the grid, a card .less change can truncate/reflow):\n${redact(diff).slice(0, 6000)}`,
         diffHint,
         '', page.instr, '',
       ]
@@ -147,7 +147,7 @@ for (const page of selected) {
   const REPORT_OUT = `/tmp/pr-review-${page.id}.json`; try { unlinkSync(REPORT_OUT); } catch {}
   const run = spawnSync('node', ['qa-runner-v2.mjs', instruction], {
     stdio: 'inherit', timeout: Number(env('AGENT_TIMEOUT_MS', '150000')), killSignal: 'SIGKILL',
-    env: { ...process.env, DIST_DIR: DIST, REPORT_OUT, MAX_TURNS: env('MAX_TURNS', '10') },
+    env: { ...process.env, DIST_DIR: DIST, REPORT_OUT, MAX_TURNS: env('MAX_TURNS', '10'), ...(page.kind === 'visual' ? { TOOLS_ALLOW: 'load_screenshots,get_console_errors,done' } : {}) },
   });
   const timedOut = run.signal === 'SIGKILL' || run.error?.code === 'ETIMEDOUT';
   let verdict = 'UNKNOWN', report = timedOut ? `Agent run exceeded the per-page time cap; partial only. (${pct}% pixels changed.)` : '(no report produced)';

--- a/.github/qa/agent-review.mjs
+++ b/.github/qa/agent-review.mjs
@@ -31,11 +31,10 @@ let diff = ''; try { diff = gh(['pr', 'diff', PR, '-R', REPO]); } catch {}
 const changed = (meta.files || []).map((f) => f.path).join('\n');
 
 const OR = 'This collection uses OR filtering: selecting one filter narrows the full set, but selecting a SECOND filter in the same group WIDENS the results (union) -- treat that increase as CORRECT, not a bug.';
-const VISUAL = `Loose VISUAL review. Budget: 6 turns, then call done(). Automated e2e tests already cover exact counts, filtering and sort order -- your ONLY job is to catch things that LOOK broken on the rendered page.
-STEP 1: Load the captured PR-vs-stable diff (load_screenshots on the path given above). Magenta marks where the PR changed rendering. Judge whether any change looks like a REGRESSION -- truncated/clipped text, a broken/missing/distorted image, overlapping or misaligned cards, wrong spacing, or low contrast -- versus a benign or intended change.
-STEP 2 (optional, 1-2 turns): if a region looks worth checking in an interacted state, open the filter panel or apply one filter (get_interactives scoped to the filter, then click) and take_screenshot -- does the result render cleanly or fall apart? Do NOT verify counts, just look.
-STEP 3: get_console_errors -- note any crash.
-STEP 4: done(report, verdict). PASS = nothing looks broken. FAIL = say exactly what looks broken and where. Judge ONLY by what you SEE, not by the code.`;
+const VISUAL = `Loose VISUAL review. Budget: 4 turns, then call done(). Automated e2e tests already cover exact counts, filtering and sort order -- your ONLY job is to catch things that LOOK broken on the rendered page. Do NOT navigate or interact; the captured diff is all you need.
+STEP 1: load_screenshots on the diff path given above. Magenta marks where the PR changed rendering. Use the "files the PR touched" hint to know WHICH components to scrutinise, then judge whether any change is a REGRESSION -- truncated/clipped text, a broken/missing/distorted image, overlapping or misaligned cards, wrong spacing, or low contrast. IMPORTANT: a live feed (e.g. news) rotates its articles/dates between the two screenshots, so a large diff can be mostly harmless CONTENT churn -- look specifically at the components the PR touched to separate a real style regression from that churn.
+STEP 2: get_console_errors -- note any crash.
+STEP 3: done(report, verdict). PASS = nothing looks broken. FAIL = say exactly what looks broken and where. Judge ONLY by what you SEE.`;
 
 const PAGES = [
   { id: 'A-left-hub', url: 'https://business.adobe.com/customer-success-stories.html',
@@ -147,7 +146,7 @@ for (const page of selected) {
       ]).join('\n');
   const REPORT_OUT = `/tmp/pr-review-${page.id}.json`; try { unlinkSync(REPORT_OUT); } catch {}
   const run = spawnSync('node', ['qa-runner-v2.mjs', instruction], {
-    stdio: 'inherit', timeout: Number(env('AGENT_TIMEOUT_MS', '120000')), killSignal: 'SIGKILL',
+    stdio: 'inherit', timeout: Number(env('AGENT_TIMEOUT_MS', '150000')), killSignal: 'SIGKILL',
     env: { ...process.env, DIST_DIR: DIST, REPORT_OUT, MAX_TURNS: env('MAX_TURNS', '10') },
   });
   const timedOut = run.signal === 'SIGKILL' || run.error?.code === 'ETIMEDOUT';

--- a/.github/qa/qa-runner-v2.mjs
+++ b/.github/qa/qa-runner-v2.mjs
@@ -346,8 +346,12 @@ const TOOLS = [
 // LLM call (sync curl)
 // ---------------------------------------------------------------------------
 
+const ACTIVE_TOOLS = process.env.TOOLS_ALLOW
+    ? TOOLS.filter((t) => process.env.TOOLS_ALLOW.split(',').map((x) => x.trim()).includes(t.name))
+    : TOOLS;
+
 function callLLM(messages) {
-    const payload = JSON.stringify({ model: MODEL, max_tokens: MAX_TOKENS, tools: TOOLS, messages });
+    const payload = JSON.stringify({ model: MODEL, max_tokens: MAX_TOKENS, tools: ACTIVE_TOOLS, messages });
     process.stdout.write(`  [llm] ${messages.length} msgs ${payload.length}b ... `);
     // Retry up to 3 times on transient proxy errors (ETIMEDOUT, 5xx, empty body).
     let lastErr = null;

--- a/less/components/consonant/cards/card.less
+++ b/less/components/consonant/cards/card.less
@@ -28,7 +28,7 @@
         -webkit-box-orient: vertical;
         margin: 0 0 7px;
 
-        .line-clamp(2);
+        .line-clamp(1);
 
         .font(1.125rem, 1.375rem, 700, @consonantGray900);
 

--- a/less/components/consonant/cards/three-fourth.less
+++ b/less/components/consonant/cards/three-fourth.less
@@ -74,7 +74,7 @@
             text-decoration: none;
             word-break: break-word;
 
-            .line-clamp(2);
+            .line-clamp(1);
 
             &:only-child {
                 max-height: 1.375rem * 4;

--- a/react/src/js/components/Consonant/Helpers/Helpers.js
+++ b/react/src/js/components/Consonant/Helpers/Helpers.js
@@ -291,7 +291,7 @@ export const getFilteredCards = (cards, activeFilters, activePanels, filterType,
             return true;
         }
         // you proceed to check the other tags in the cards after the time filter checks
-        const tagIds = new Set(card.tags.map(tag => tag.id));
+        const tagIds = new Set(card.tags.map(tag => tag.name));
 
         if (usingXorAndFilter) {
             // When filterGroups are provided (from category expansion), check that


### PR DESCRIPTION
Throwaway validation PR. Seeds TWO deliberate regressions: (1) card titles truncated to one line (visual, should be flagged on the card pages + gallery), (2) OR filter returns zero results via tag.id->tag.name (functional, should be flagged on the left/top filter pages). The multi-page agent should run all 5 pages and flag these. Will be closed.