### PR TITLE
feat(mwpw-199538): add caas-endpoint query param to override API base URL

### DIFF
--- a/react/src/js/components/Consonant/Container/Container.jsx
+++ b/react/src/js/components/Consonant/Container/Container.jsx
@@ -49,6 +49,7 @@ import {
     ONE_SECOND_DELAY,
     SORT_TYPES,
     EVENT_TIMING_IDS,
+    CAAS_ENDPOINT_MAP,
 } from '../Helpers/constants';
 import {
     ConfigContext,
@@ -1015,6 +1016,12 @@ const Container = (props) => {
 
         let collectionEndpoint = getConfig('collection', 'endpoint');
         const fallbackEndpoint = getConfig('collection', 'fallbackEndpoint');
+
+        const caasEndpointKey = new URLSearchParams(window.location.search).get('caas-endpoint');
+        const endpointOverride = CAAS_ENDPOINT_MAP[caasEndpointKey];
+        if (endpointOverride && collectionEndpoint.startsWith(endpointOverride.from)) {
+            collectionEndpoint = endpointOverride.to + collectionEndpoint.slice(endpointOverride.from.length);
+        }
 
         const r = new RegExp('^(?:[a-z]+:)?//', 'i');
         let collectionEndpointURI;

--- a/react/src/js/components/Consonant/Helpers/constants.js
+++ b/react/src/js/components/Consonant/Helpers/constants.js
@@ -4,6 +4,13 @@
  */
 export const DESKTOP_MIN_WIDTH = 1200;
 
+export const CAAS_ENDPOINT_MAP = {
+    smoketest: {
+        from: 'https://www.adobe.com/chimera-api/',
+        to: 'https://14257-chimera-smoketest.adobeioruntime.net/api/v1/web/chimera-0.0.1/',
+    },
+};
+
 /**
  * Minimal viewport width to fit tablets
  * @type {Number}


### PR DESCRIPTION
## Summary
- Adds a `?caas-endpoint=<key>` query parameter to allow overriding the CaaS API base URL at runtime
- Keys map to allowlisted alternative endpoints via `CAAS_ENDPOINT_MAP` in `constants.js`; unknown keys silently fall back to the configured endpoint
- Initial mapping: `smoketest` → `https://14257-chimera-smoketest.adobeioruntime.net/api/v1/web/chimera-0.0.1/`

## Test plan
- [ ] Load a CaaS page without the query param — confirm requests go to the production endpoint
- [ ] Load with `?caas-endpoint=smoketest` — confirm requests go to the smoketest endpoint with the same path and query params preserved
- [ ] Load with `?caas-endpoint=invalid` — confirm requests fall back to the production endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)