### PR TITLE
fix(mwpw-199538): guard caas-endpoint lookup against prototype chain

### DIFF
--- a/react/src/js/components/Consonant/Container/Container.jsx
+++ b/react/src/js/components/Consonant/Container/Container.jsx
@@ -1018,7 +1018,12 @@ const Container = (props) => {
         const fallbackEndpoint = getConfig('collection', 'fallbackEndpoint');
 
         const caasEndpointKey = new URLSearchParams(window.location.search).get('caas-endpoint');
-        const endpointOverride = CAAS_ENDPOINT_MAP[caasEndpointKey];
+        const endpointOverride = Object.prototype.hasOwnProperty.call(
+            CAAS_ENDPOINT_MAP,
+            caasEndpointKey,
+        )
+            ? CAAS_ENDPOINT_MAP[caasEndpointKey]
+            : undefined;
         if (endpointOverride && collectionEndpoint.startsWith(endpointOverride.from)) {
             collectionEndpoint = endpointOverride.to + collectionEndpoint.slice(endpointOverride.from.length);
         }


### PR DESCRIPTION
Follow-up hotfix to #537 (shipped in v0.56.0).

## Problem
`#537` added a runtime override:

```js
const endpointOverride = CAAS_ENDPOINT_MAP[caasEndpointKey]; // key comes from ?caas-endpoint=
```

The key is user-controlled (URL) and the lookup is on a plain object, so it falls through to `Object.prototype`. On any embedding surface that has a prototype-pollution bug (common in query-param parsers), an attacker can plant a fake entry and weaponize this lookup:

```
adobe.com/page.html?__proto__[x][to]=https://attacker.com&caas-endpoint=x
```

1. `__proto__[x][to]=...` abuses the consumer page parser to write `x = { to: attacker.com }` onto `Object.prototype`.
2. `caas-endpoint=x` makes CaaS look up `x`; it is not an own key of `CAAS_ENDPOINT_MAP`, so the lookup resolves the planted prototype entry.
3. `from` prefix matches, so CaaS fetches its collection from `attacker.com` → attacker controls every card/link rendered on a real adobe.com page (content injection / phishing under our domain).

It is conditional on the embedding page having a pollution bug, but CaaS runs across surfaces we do not own or audit, so we should not depend on that being false everywhere.

## Fix
Resolve only **own** keys of the allowlist, so the lookup can never reach the prototype chain:

```js
const endpointOverride = Object.prototype.hasOwnProperty.call(CAAS_ENDPOINT_MAP, caasEndpointKey)
    ? CAAS_ENDPOINT_MAP[caasEndpointKey]
    : undefined;
```

One statement changed. (`Map` + `.get()` would be equivalent.)

## Verified
- `?caas-endpoint=smoketest` → still redirects to smoketest (happy path unchanged)
- unknown / `__proto__` / `null` keys → no-op
- `evilkey` on a deliberately polluted `Object.prototype` → **no-op** (pre-fix this redirected to the attacker)
- eslint clean

## Note on v0.56.0
The vulnerable code is already in the cut `v0.56.0` release, so a forward fix alone does not retire it (`?caasver=0.56.0` could reload it). The `0.56.0` build is being removed from docroot so it cannot load; this PR fixes `main` forward.