### PR TITLE
test(mwpw-184989): repro getConfig pattern to validate AI review context [DO NOT MERGE]

### DIFF
--- a/react/src/js/components/Consonant/Cards/FlexCard.jsx
+++ b/react/src/js/components/Consonant/Cards/FlexCard.jsx
@@ -5,6 +5,7 @@ import CardHeader from './CardHeader/CardHeader';
 import CardContent from './CardContent/CardContent';
 import CardFooter from './CardFooter/CardFooter';
 import LinkBlocker from './LinkBlocker/LinkBlocker';
+import { useConfig } from '../Helpers/hooks';
 
 const FlexCard = () => {
     const {
@@ -35,6 +36,13 @@ const FlexCard = () => {
     const textSize = flexCardOptions?.textSize || '';
     const textSizeClass = textSize === 'text-large' ? 'text-large' : '';
 
+    const getConfig = useConfig();
+    const detailsTextOption = getConfig('collection', 'detailsTextOption');
+    const products = detailsTextOption === 'productName'
+        ? Object.values(getConfig('products', '') || {})
+        : [];
+    const productMatch = products.find(product => product.tagID === detailText) || null;
+
     return (
         <li
             daa-lh={lh}
@@ -42,7 +50,8 @@ const FlexCard = () => {
             data-testid="consonant-Card"
             id={id}
             {...(country && { 'data-country': country })}
-            {...(reference && { 'data-card-url': reference })}>
+            {...(reference && { 'data-card-url': reference })}
+            {...(productMatch && { 'data-product': productMatch.tagID })}>
             {imageOption !== 'hidden' && <CardHeader
                 image={optimizedImage}
                 imageOption={imageOption}


### PR DESCRIPTION
Test-only PR (do not merge) to validate the AI code review depth-2 source-context change.

It reproduces the exact `getConfig` usage the AI reviewer repeatedly misread on #532 (claiming the empty-string second arg of `getConfig('products', '')` is a default value, and suggesting the broken `getConfig('products', {})`).

With the new source context (changed file + 2-hop relative imports), the bot should now pull `hooks.js` -> `consonant.js` and read `makeConfigGetter`/`getByPath`, so it understands the real `(group, subKey)` signature and does NOT repeat the misread.

Watching the AI review comment to confirm. Will close after.