### PR TITLE
fix(mwpw-196902): switch proxy validation model to claude-sonnet-5

### DIFF
--- a/.github/workflows/validate-ims-token.yml
+++ b/.github/workflows/validate-ims-token.yml
@@ -17,7 +17,7 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.IMS_ACCESS_TOKEN }}" \
             -H "Content-Type: application/json" \
             -H "anthropic-version: 2023-06-01" \
-            -d '{"model":"claude-sonnet-4-6","max_tokens":30,"messages":[{"role":"user","content":"Reply with only: token validated."}]}')
+            -d '{"model":"claude-sonnet-5","max_tokens":30,"messages":[{"role":"user","content":"Reply with only: token validated."}]}')
 
           if echo "$RESPONSE" | grep -q '"type":"message"'; then
             echo "status=success" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- `claude-sonnet-4-6` is no longer on the `adobe-llm-proxy.paolo-moz.workers.dev` allowlist — proxy returns 403
- Confirmed `claude-sonnet-5` works against the proxy

## Test plan
- [ ] Merge and trigger `validate-ims-token` workflow manually — should post ✅ comment on issue #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)