### PR TITLE
fix(mwpw-200160): handle extended thinking blocks in AI review parser

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -296,7 +296,11 @@ jobs:
               review = "AI review unavailable (upstream error). See Actions logs."
           else:
               try:
-                  review = json.loads(body)['content'][0]['text']
+                  blocks = json.loads(body)['content']
+                  text_block = next((b for b in blocks if b.get('type') == 'text'), None)
+                  if text_block is None:
+                      raise ValueError('no text block in response')
+                  review = text_block['text']
               except Exception as e:
                   print(f"Parse error: {e}", file=sys.stderr)
                   print(body[:2000], file=sys.stderr)


### PR DESCRIPTION
## Summary
- When `LLM_MODEL` points to a model that returns extended thinking, `content[0]` is a `{"type":"thinking"}` block, not `{"type":"text"}` — the parser was crashing with `KeyError: 'text'`
- Fix: find the first `type == "text"` block instead of assuming index 0

## Test plan
- [ ] Trigger AI review on a PR with a model that returns thinking blocks — confirm review posts correctly instead of "response parse error"

🤖 Generated with [Claude Code](https://claude.com/claude-code)