### PR TITLE
fix(mwpw-200160): raise AI review max_tokens to 16k for thinking models

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -268,7 +268,7 @@ jobs:
 
           payload = json.dumps({
               "model": model,
-              "max_tokens": 16000,
+              "max_tokens": 32000,
               "messages": [{"role": "user", "content": content}]
           })
 

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -268,7 +268,7 @@ jobs:
 
           payload = json.dumps({
               "model": model,
-              "max_tokens": 2048,
+              "max_tokens": 16000,
               "messages": [{"role": "user", "content": content}]
           })
 

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -124,7 +124,7 @@ jobs:
           # ---- budgets (chars; ~4 chars/token, model window ~200k tokens) ----
           MAX_DIFF_CHARS = 180000
           MAX_CODE_CHARS = 150000
-          MAX_COMMENT_CHARS = 12000
+          MAX_COMMENT_CHARS = 50000
           IMPORT_HOPS = 2          # changed files + 2 levels of their imports
           MAX_CONTEXT_FILES = 40   # guard against hub-file fan-out
 

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -124,7 +124,7 @@ jobs:
           # ---- budgets (chars; ~4 chars/token, model window ~200k tokens) ----
           MAX_DIFF_CHARS = 180000
           MAX_CODE_CHARS = 150000
-          MAX_COMMENT_CHARS = 50000
+          MAX_COMMENT_CHARS = 12000
           IMPORT_HOPS = 2          # changed files + 2 levels of their imports
           MAX_CONTEXT_FILES = 40   # guard against hub-file fan-out
 


### PR DESCRIPTION
## Summary
-  engages extended thinking on large code review prompts
- With `max_tokens: 2048` the entire budget is consumed by thinking, leaving no room for the text response — resulting in a response with only thinking blocks and no text
- Raises to 16000 to give the model sufficient headroom

## Test plan
- [ ] Merge and comment `@ai-bot` on PR #532 — should produce a real review instead of parse error