### PR TITLE
fix(mwpw-200284): allows styling for secondary links

### DIFF
--- a/react/src/js/components/Consonant/Infobit/Group.jsx
+++ b/react/src/js/components/Consonant/Infobit/Group.jsx
@@ -124,7 +124,18 @@ const Group = (props) => {
                         );
 
                     case INFOBIT_TYPE.LINK:
-                        if (infobit.style === "button") return '';
+                        if (infobit.style === 'button') return '';
+                        if (infobit.style === 'primary' || infobit.style === 'call-to-action') {
+                            return (
+                                <Button
+                                    {...infobit}
+                                    key={cuid()}
+                                    onFocus={onFocus}
+                                    title={title}
+                                    tabIndex={tabIndex}
+                                    renderOverlay={renderOverlay} />
+                            );
+                        }
                         return (
                             <TextLink
                                 {...infobit}

--- a/react/src/js/components/Consonant/Infobit/__test__/Group.spec.js
+++ b/react/src/js/components/Consonant/Infobit/__test__/Group.spec.js
@@ -84,6 +84,41 @@ describe('Consonant/Infobits/Group', () => {
     expect(linkElement).toHaveAttribute('href', 'https://example.com');
   });
 
+  test('Should render Link infobit with style "primary" as a Button', () => {
+    const title = 'Link Title';
+    const renderList = [
+      {
+        type: INFOBIT_TYPE.LINK,
+        style: 'primary',
+        href: 'https://example.com',
+        text: 'Primary Link'
+      }
+    ];
+
+    render(<Group renderList={renderList} title={title} />);
+    const buttonElement = screen.getByTestId('consonant-BtnInfobit');
+    expect(buttonElement).toBeInTheDocument();
+    expect(buttonElement).toHaveAttribute('href', 'https://example.com');
+    expect(buttonElement.textContent).toBe('Primary Link');
+  });
+
+  test('Should render Link infobit with style "call-to-action" as a Button', () => {
+    const renderList = [
+      {
+        type: INFOBIT_TYPE.LINK,
+        style: 'call-to-action',
+        href: 'https://example.com',
+        text: 'CTA Link'
+      }
+    ];
+
+    render(<Group renderList={renderList} />);
+    const buttonElement = screen.getByTestId('consonant-BtnInfobit');
+    expect(buttonElement).toBeInTheDocument();
+    expect(buttonElement).toHaveAttribute('href', 'https://example.com');
+    expect(buttonElement.textContent).toBe('CTA Link');
+  });
+
   test('Should render Gated infobit correctly', () => {
     const renderList = [
       {


### PR DESCRIPTION
**Summary**
- Renders LINK infobits with style: "primary" or style: "call-to-action" as a Button component instead of a TextLink
- Adds unit tests covering both new style branches to close a coverage gap

**Resolves**:  MWPW-200284

**Changes**
- react/src/js/components/Consonant/Infobit/Group.jsx — in the INFOBIT_TYPE.LINK case, LINK infobits styled "primary" or "call-to-action" now render via Button (passing through onFocus, title, tabIndex, renderOverlay) instead of falling through to TextLink
- react/src/js/components/Consonant/Infobit/__test__/Group.spec.js — added tests asserting style: "primary" and style: "call-to-action" LINK infobits render as a Button with correct href/text content

**Usage**
```
cta2URL:   https://adobe.com
cta2Text:  Another CTA
cta2Style: primary
```

**Before**:
<img width="397" height="466" alt="Screenshot 2026-07-09 at 9 23 08 AM" src="https://github.com/user-attachments/assets/612ce6b9-3bc3-43a0-b663-c694278abd76" />

**After**:
<img width="404" height="471" alt="Screenshot 2026-07-09 at 9 22 53 AM" src="https://github.com/user-attachments/assets/c70f1d5c-e570-4122-9f35-2ac9d07e6ace" />


**Test plan**
- [x] Verify a LINK infobit with style: "primary" renders as a button-styled CTA in a card footer
- [x] Verify a LINK infobit with style: "call-to-action" renders as a button-styled CTA in a card footer
- [x] Confirm LINK infobits with no style (or other styles) still render as TextLink (no regression)
- [x] Unit tests added/updated

