### PR TITLE
feat(mwpw-184989): add ?caasqa-gated localStorage config override for automated QA

### DIFF
--- a/react/src/js/app.jsx
+++ b/react/src/js/app.jsx
@@ -3,7 +3,7 @@ import "./polyfills";
 import React from 'react';
 import ReactDOM, { render } from 'react-dom';
 import { DOMRegistry } from 'react-dom-components';
-import { parseToPrimitive } from './components/Consonant/Helpers/general';
+import { parseToPrimitive, applyQaConfigOverride } from './components/Consonant/Helpers/general';
 import { loadLana } from './components/Consonant/Helpers/lana';
 import Container from './components/Consonant/Container/Container';
 import consonantPageRDC from './components/Consonant/Page/ConsonantPageDOM';
@@ -77,7 +77,7 @@ export class ConsonantCardCollecton {
     constructor(config, element) {
         ReactDOM.render((
             <React.Fragment>
-                <Container config={parseToPrimitive(config)} />
+                <Container config={applyQaConfigOverride(parseToPrimitive(config))} />
             </React.Fragment>), element);
     }
 }

--- a/react/src/js/components/Consonant/Helpers/__tests__/general.spec.js
+++ b/react/src/js/components/Consonant/Helpers/__tests__/general.spec.js
@@ -30,6 +30,7 @@ import {
     getSelectedItemsCount,
     debounce,
     mergeDeep,
+    applyQaConfigOverride,
     template,
     optimizeImageUrl,
     preloadFirstCardImage,
@@ -304,6 +305,42 @@ describe('utils/general', () => {
 
                 expect(target).toEqual(expectedValue);
             });
+        });
+    });
+    describe('applyQaConfigOverride', () => {
+        const setSearch = (search) => {
+            window.history.pushState({}, '', `/${search}`);
+        };
+        afterEach(() => {
+            window.localStorage.removeItem('caasQaConfig');
+            setSearch('');
+        });
+
+        test('is a no-op without the ?caasqa gate param', () => {
+            setSearch('');
+            window.localStorage.setItem('caasQaConfig', JSON.stringify({ sort: { localFirstRecencyThreshold: 6 } }));
+            expect(applyQaConfigOverride({ sort: { enabled: true } }))
+                .toEqual({ sort: { enabled: true } });
+        });
+
+        test('deep-merges the stored override when ?caasqa is present', () => {
+            setSearch('?caasqa=1');
+            window.localStorage.setItem('caasQaConfig', JSON.stringify({ sort: { localFirstRecencyThreshold: 6 } }));
+            expect(applyQaConfigOverride({ sort: { enabled: true }, collection: { size: 10 } }))
+                .toEqual({ sort: { enabled: true, localFirstRecencyThreshold: 6 }, collection: { size: 10 } });
+        });
+
+        test('is a no-op when gated but nothing is stored', () => {
+            setSearch('?caasqa=1');
+            expect(applyQaConfigOverride({ sort: { enabled: true } }))
+                .toEqual({ sort: { enabled: true } });
+        });
+
+        test('returns config unchanged on invalid JSON (no throw)', () => {
+            setSearch('?caasqa=1');
+            window.localStorage.setItem('caasQaConfig', '{not valid json');
+            expect(applyQaConfigOverride({ sort: { enabled: true } }))
+                .toEqual({ sort: { enabled: true } });
         });
     });
     describe('template', () => {

--- a/react/src/js/components/Consonant/Helpers/general.js
+++ b/react/src/js/components/Consonant/Helpers/general.js
@@ -423,6 +423,28 @@ export const mergeDeep = (target, ...sources) => {
     return mergeDeep(target, ...sources);
 };
 
+/**
+ * QA-only config override. Prod-safe: a no-op unless the page URL carries the
+ * `?caasqa` gate param. When gated, it deep-merges a JSON config override read from
+ * localStorage['caasQaConfig'] over the real config -- letting automated QA force a
+ * feature's config (e.g. sort.localFirstRecencyThreshold) that no live page authors.
+ * Client-side only: it changes nothing but the current browser tab's own render.
+ */
+export const applyQaConfigOverride = (config) => {
+    try {
+        if (typeof window === 'undefined' || !window.location || !window.localStorage) return config;
+        const params = new URLSearchParams(window.location.search || '');
+        if (!params.has('caasqa')) return config;
+        const raw = window.localStorage.getItem('caasQaConfig');
+        if (!raw) return config;
+        const override = JSON.parse(raw);
+        if (!isObject(override)) return config;
+        return mergeDeep(config, override);
+    } catch (e) {
+        return config;
+    }
+};
+
 const isCaasGroup = group => group.indexOf('ch_') === 0;
 
 /**


### PR DESCRIPTION
## Summary

Adds a **prod-safe, QA-only** config override so automated QA can force a CaaS feature's config that no live page authors.

- New helper `applyQaConfigOverride(config)` in `Helpers/general.js`, wired into `app.jsx` at the single point where the config is finalized (`<Container config={...}>`).
- **Gated:** a complete no-op unless the page URL carries `?caasqa`. When gated, it deep-merges a JSON config override read from `localStorage['caasQaConfig']` over the real config (reusing the existing `mergeDeep`).
- Client-side only — changes nothing but the current browser tab's own render, and never fires for real users (no `?caasqa`, no override).

## Why

Config-gated features (e.g. `sort.localFirstRecencyThreshold` in #468) never activate on any live page, so the automated agent QA review can only smoke-test around them. This hook lets the QA harness set the exact config a feature needs, before mount, so the feature actually renders and can be exercised end-to-end in a real browser.

## Usage

```js
localStorage.setItem('caasQaConfig', JSON.stringify({ sort: { localFirstRecencyThreshold: 6 } }));
// then load <collection-page>?caasqa=1
```

## Tests

4 unit tests in `general.spec.js`: no-op without the gate, deep-merges with the gate, no-op when nothing is stored, and no-throw on invalid JSON.

## Safety

- No effect at all without `?caasqa` in the URL.
- Wrapped in try/catch — any error returns the original config unchanged.
- Client-side, single-tab only; no server-side or cross-user impact (a user can already tweak their own page via devtools).
