### PR TITLE
feat(mwpw-199546): allows links and line breaks in description

### DIFF
--- a/less/components/consonant/cards/flex.less
+++ b/less/components/consonant/cards/flex.less
@@ -204,6 +204,29 @@
             }
         }
 
+        &.text-left {
+            .consonant-CardFooter-row {
+                justify-content: flex-start;
+            }
+
+            .consonant-CardFooter-cell {
+                flex-grow: 0;
+            }
+
+            .consonant-CardFooter-cell--left {
+                padding-right: 20px;
+            }
+
+            .consonant-CardFooter-cell--center {
+                justify-content: flex-start;
+                padding-right: 20px;
+            }
+
+            .consonant-CardFooter-cell--right {
+                justify-content: flex-start;
+            }
+        }
+
         &.text-center {
             .consonant-Card-content * {
                 text-align: center;

--- a/less/components/consonant/cards/flex.less
+++ b/less/components/consonant/cards/flex.less
@@ -142,6 +142,7 @@
 
         .consonant-Card-text {
             flex-grow: 1;
+            margin: 0;
 
             &:last-child {
                 margin: 0;
@@ -149,18 +150,24 @@
         }
 
         .consonant-CardFooter {
-            padding: 20px 0 0 0;
-
-            &--divider {
-                margin-top: 10px;
-            }
+            padding: 0;
 
             .consonant-CardFooter-row:has(.consonant-CardFooter-cell--right) {
                 height: auto;
+                margin-top: 12px;
+                padding: 20px 0 0 0;
             }
 
             .consonant-CardFooter-cell--left {
                 font-size: 0.875rem;
+            }
+
+            &--divider {
+                margin-top: 20px;
+
+                .consonant-CardFooter-row:has(.consonant-CardFooter-cell--right) {
+                    margin-top: 0;
+                }
             }
         }
 

--- a/less/components/consonant/cards/flex.less
+++ b/less/components/consonant/cards/flex.less
@@ -2,6 +2,16 @@
     .consonant-Card.flex-card {
         .card-hover;
 
+        &.rounded-corners {
+            border-radius: 20px;
+
+            .consonant-Card-header {
+                width: 95%;
+                margin: 8px auto;
+                border-radius: 12px;
+            }
+        }
+
         &:not([class *= "image-small-"]) {
             .card-hover-header;
         }
@@ -130,13 +140,27 @@
             }
         }
 
-        &.rounded-corners {
-            border-radius: 20px;
+        .consonant-Card-text {
+            flex-grow: 1;
 
-            .consonant-Card-header {
-                width: 95%;
-                margin: 8px auto;
-                border-radius: 12px;
+            &:last-child {
+                margin: 0;
+            }
+        }
+
+        .consonant-CardFooter {
+            padding: 20px 0 0 0;
+
+            &--divider {
+                margin-top: 10px;
+            }
+
+            .consonant-CardFooter-row:has(.consonant-CardFooter-cell--right) {
+                height: auto;
+            }
+
+            .consonant-CardFooter-cell--left {
+                font-size: 0.875rem;
             }
         }
 
@@ -152,10 +176,6 @@
 
             .consonant-Card-content {
                 padding: 0 24px 12px;
-            }
-
-            .consonant-CardFooter {
-                padding-top: 12px;
             }
         }
 
@@ -260,4 +280,8 @@
 
 p.consonant-Card-text p:first-child {
     margin: 0;
+}
+
+p.consonant-Card-text br:first-child {
+    display: none;
 }

--- a/less/components/consonant/cards/flex.less
+++ b/less/components/consonant/cards/flex.less
@@ -257,3 +257,7 @@
         }
     }
 }
+
+p.consonant-Card-text p:first-child {
+    margin: 0;
+}

--- a/react/src/js/components/Consonant/Cards/Card.jsx
+++ b/react/src/js/components/Consonant/Cards/Card.jsx
@@ -410,6 +410,16 @@ const Card = (props) => {
     const cta2Text = getCtaText(footer, 'center');
     const overlay = (altCtaUsed && isLive && altCtaLink !== '') ? altCtaLink : overlayParams;
 
+    // Parse CTA links
+    const parseLinks = (markup) => {
+        const cta1Url = getCtaLink(footer, 'right');
+        const cta1Text = getCtaText(footer, 'right');
+        const cta2Url = getCtaLink(footer, 'center');
+        return markup
+            .replaceAll('{link:cta1}', `<a href="${cta1Url}">${cta1Text}</a>`)
+            .replaceAll('{link:cta2}', `<a href="${cta2Url}">${cta2Text}</a>`);
+    };
+
     const parseMarkDown = (md = '') => {
         if (searchEnabled) {
             return removeMarkDown(md.replace(/<[^>]*>/g, ''));
@@ -431,16 +441,6 @@ const Card = (props) => {
         }
     
         return markup;
-    };
-
-    // CTA links
-    const parseLinks = (markup) => {
-        const cta1Url = getCtaLink(footer, 'right');
-        const cta1Text = getCtaText(footer, 'right');
-        const cta2Url = getCtaLink(footer, 'center');
-        return markup
-            .replaceAll('{link:cta1}', `<a href="${cta1Url}">${cta1Text}</a>`)
-            .replaceAll('{link:cta2}', `<a href="${cta2Url}">${cta2Text}</a>`);
     };
 
     const optimizedImage = optimizeImageUrl(image);

--- a/react/src/js/components/Consonant/Cards/Card.jsx
+++ b/react/src/js/components/Consonant/Cards/Card.jsx
@@ -323,6 +323,25 @@ const Card = (props) => {
         return '';
     }
 
+    function getCtaLink(footerData, ctaUsed) {
+        if (!footerData) return '';
+        if (footerData.length === 1) {
+            const {
+                altCta = [],
+                right = [],
+                center = [],
+            } = footerData[0];
+            if (ctaUsed === 'right' && right.length === 1) {
+                return right[0].href;
+            } else if (ctaUsed === 'center' && center.length === 1) {
+                return center[0].href;
+            } else if (ctaUsed === 'alt' && altCta.length === 1) {
+                return altCta[0].href;
+            }
+        }
+        return '';
+    }
+
     const isHalfHeight = cardStyle === 'half-height';
     const isProduct = cardStyle === 'product';
     const isBlade = cardStyle === 'blade-card';
@@ -402,31 +421,84 @@ const Card = (props) => {
             .replaceAll('{**', '<b>')
             .replaceAll('**}', '</b>')
             .replaceAll('{*', '<i>')
-            .replaceAll('*}', '</i>');
+            .replaceAll('*}', '</i>')
+            .replaceAll('\n', '<p>');
+
+        if (markup.includes('{link:')) {
+            return parseLinks(markup);
+        }
+
         return markup;
+    };
+
+    const parseLinks = (markup) => {
+        const cta1Url = getCtaLink(footer, 'right');
+        const cta1Text = getCtaText(footer, 'right');
+        const cta2Url = getCtaLink(footer, 'center');
+        return markup
+            .replaceAll('{link:cta1}', `<a href="${cta1Url}">${cta1Text}</a>`)
+            .replaceAll('{link:cta2}', `<a href="${cta2Url}">${cta2Text}</a>`);
     };
 
     const optimizedImage = optimizeImageUrl(image);
 
     const cardData = useMemo(() => ({
-        id, country, reference, lh, cardClassName, cardStyle, bladeVariant,
-        optimizedImage, altText, cta2Text, flexCardOptions,
-        hasBanner, disableBanners,
+        id,
+country,
+reference,
+lh,
+cardClassName,
+cardStyle,
+bladeVariant,
+        optimizedImage,
+altText,
+cta2Text,
+flexCardOptions,
+        hasBanner,
+disableBanners,
         bannerBackgroundColor: bannerBackgroundColorToUse,
         bannerFontColor: bannerFontColorToUse,
         bannerIcon: bannerIconToUse,
         bannerDescription: bannerDescriptionToUse,
-        badgeText, fromDexter, showCardBadges,
-        videoURL, videoURLToUse, gateVideo, useCenterVideoPlay,
-        logoSrc, logoAlt, logoBg, logoBorderBg, image,
-        cardIcon, iconAlt,
-        detailText, editorialOpenVariant,
-        highlightedTitle, title, headingAria, headingLevel,
-        highlightedDescription, description, parseMarkDown,
-        footer, renderDivider, cardDate, startDate, endDate,
-        extendFooterData, altCtaUsed, hideOnDemandDates,
-        linkBlockerTarget, overlay, ctaText,
-        onFocus, tabIndex, ariaHidden, renderOverlay, hideCTA,
+        badgeText,
+fromDexter,
+showCardBadges,
+        videoURL,
+videoURLToUse,
+gateVideo,
+useCenterVideoPlay,
+        logoSrc,
+logoAlt,
+logoBg,
+logoBorderBg,
+image,
+        cardIcon,
+iconAlt,
+        detailText,
+editorialOpenVariant,
+        highlightedTitle,
+title,
+headingAria,
+headingLevel,
+        highlightedDescription,
+description,
+parseMarkDown,
+        footer,
+renderDivider,
+cardDate,
+startDate,
+endDate,
+        extendFooterData,
+altCtaUsed,
+hideOnDemandDates,
+        linkBlockerTarget,
+overlay,
+ctaText,
+        onFocus,
+tabIndex,
+ariaHidden,
+renderOverlay,
+hideCTA,
     }));
 
     const CardComponent = CARD_STYLES[cardStyle] || OneHalf;

--- a/react/src/js/components/Consonant/Cards/Card.jsx
+++ b/react/src/js/components/Consonant/Cards/Card.jsx
@@ -245,6 +245,8 @@ const Card = (props) => {
     } else if (detailsTextOption === 'staticDate' && cardDate) {
         const staticDate = new Date(cardDate.replace(/Z$/, ''));
         detailText = staticDate.toLocaleDateString();
+    } else if (detailsTextOption === 'hidden') {
+        detailText = '';
     } else if (detailsTextOption === 'productName' && cardStyle !== 'flex-card') {
         detailText = '';
     }
@@ -422,15 +424,16 @@ const Card = (props) => {
             .replaceAll('**}', '</b>')
             .replaceAll('{*', '<i>')
             .replaceAll('*}', '</i>')
-            .replaceAll('\n', '<p>');
+            .replaceAll('\n', '<br/>');
 
-        if (markup.includes('{link:')) {
+        if (markup.toLowerCase().includes('{link:')) {
             return parseLinks(markup);
         }
-
+    
         return markup;
     };
 
+    // CTA links
     const parseLinks = (markup) => {
         const cta1Url = getCtaLink(footer, 'right');
         const cta1Text = getCtaText(footer, 'right');
@@ -444,61 +447,61 @@ const Card = (props) => {
 
     const cardData = useMemo(() => ({
         id,
-country,
-reference,
-lh,
-cardClassName,
-cardStyle,
-bladeVariant,
+        country,
+        reference,
+        lh,
+        cardClassName,
+        cardStyle,
+        bladeVariant,
         optimizedImage,
-altText,
-cta2Text,
-flexCardOptions,
+        altText,
+        cta2Text,
+        flexCardOptions,
         hasBanner,
-disableBanners,
+        disableBanners,
         bannerBackgroundColor: bannerBackgroundColorToUse,
         bannerFontColor: bannerFontColorToUse,
         bannerIcon: bannerIconToUse,
         bannerDescription: bannerDescriptionToUse,
         badgeText,
-fromDexter,
-showCardBadges,
+        fromDexter,
+        showCardBadges,
         videoURL,
-videoURLToUse,
-gateVideo,
-useCenterVideoPlay,
+        videoURLToUse,
+        gateVideo,
+        useCenterVideoPlay,
         logoSrc,
-logoAlt,
-logoBg,
-logoBorderBg,
-image,
+        logoAlt,
+        logoBg,
+        logoBorderBg,
+        image,
         cardIcon,
-iconAlt,
+        iconAlt,
         detailText,
-editorialOpenVariant,
+        editorialOpenVariant,
         highlightedTitle,
-title,
-headingAria,
-headingLevel,
+        title,
+        headingAria,
+        headingLevel,
         highlightedDescription,
-description,
-parseMarkDown,
+        description,
+        parseMarkDown,
         footer,
-renderDivider,
-cardDate,
-startDate,
-endDate,
+        renderDivider,
+        cardDate,
+        startDate,
+        endDate,
         extendFooterData,
-altCtaUsed,
-hideOnDemandDates,
+        altCtaUsed,
+        hideOnDemandDates,
         linkBlockerTarget,
-overlay,
-ctaText,
+        overlay,
+        ctaText,
         onFocus,
-tabIndex,
-ariaHidden,
-renderOverlay,
-hideCTA,
+        tabIndex,
+        ariaHidden,
+        renderOverlay,
+        hideCTA,
     }));
 
     const CardComponent = CARD_STYLES[cardStyle] || OneHalf;

--- a/react/src/js/components/Consonant/Cards/CardFooter/CardFooter.jsx
+++ b/react/src/js/components/Consonant/Cards/CardFooter/CardFooter.jsx
@@ -42,7 +42,6 @@ const CardFooter = (props) => {
         cardDate,
         startDate,
         endDate,
-        staticDate,
         isFluid,
         onFocus,
         title,

--- a/react/src/js/components/Consonant/Cards/CardFooter/CardFooter.jsx
+++ b/react/src/js/components/Consonant/Cards/CardFooter/CardFooter.jsx
@@ -42,6 +42,7 @@ const CardFooter = (props) => {
         cardDate,
         startDate,
         endDate,
+        staticDate,
         isFluid,
         onFocus,
         title,
@@ -49,6 +50,8 @@ const CardFooter = (props) => {
         renderOverlay,
         hideCTA,
         isBlog,
+        isFlexCard,
+        showDateOnFooter,
     } = props;
 
     /**
@@ -88,7 +91,7 @@ const CardFooter = (props) => {
      * Whether the left footer infobits should render
      * @type {Boolean}
      */
-    const shouldRenderLeft = (left && left.length > 0) || (isBlog && cardDate);
+    const shouldRenderLeft = (left && left.length > 0) || (isBlog && cardDate) || (isFlexCard && showDateOnFooter && cardDate);
 
     /**
      * Whether the center footer infobits should render
@@ -153,6 +156,7 @@ const CardFooter = (props) => {
                 <div
                     className="consonant-CardFooter-cell consonant-CardFooter-cell--left">
                     {isBlog && <span>{formattedCardDate}</span>}
+                    {isFlexCard && showDateOnFooter && !endDate&& <span>{formattedCardDate}</span>}
                     <Group renderList={left} onFocus={onFocus} />
                 </div>
                 }

--- a/react/src/js/components/Consonant/Cards/CardFooter/CardFooter.jsx
+++ b/react/src/js/components/Consonant/Cards/CardFooter/CardFooter.jsx
@@ -138,12 +138,29 @@ const CardFooter = (props) => {
         altRightLive.push(live);
     }
 
-    // Format date for blog card
-    const formattedCardDate = cardDate
-        ? `${String(cardDate.getMonth() + 1)
-            .padStart(2, '0')}-${String(cardDate.getDate())
-            .padStart(2, '0')}-${cardDate.getFullYear()}`
-        : '';
+    // Format date for flex card mm/dd/yyyy
+    const formattedFlexCardDate = () => {
+        const date = new Date(cardDate);
+        if (date) {
+            return `${String(date.getMonth() + 1)}/${String(date.getDate())}/${date.getFullYear()}`;
+        }
+        return '';
+    }
+
+    // Format date for blog card mm-dd-yyyy
+    const formattedBlogCardDate = () => {
+        const date = new Date(cardDate);
+        if (date) {
+            // Remove timezone by constructing a new Date from the date components only (local)
+            const dateObj = typeof cardDate === 'string'
+                ? new Date(cardDate.slice(0, 10)) // e.g. '2023-05-01T12:00:00Z' => '2023-05-01'
+                : new Date(cardDate.getFullYear(), cardDate.getMonth(), cardDate.getDate());
+            return `${String(dateObj.getMonth() + 1)
+                .padStart(2, '0')}-${String(dateObj.getDate())
+                .padStart(2, '0')}-${dateObj.getFullYear()}`;
+        }
+        return '';
+    }
     
     return (
         <div
@@ -155,8 +172,8 @@ const CardFooter = (props) => {
                 {shouldRenderLeft &&
                 <div
                     className="consonant-CardFooter-cell consonant-CardFooter-cell--left">
-                    {isBlog && <span>{formattedCardDate}</span>}
-                    {isFlexCard && showDateOnFooter && !endDate&& <span>{formattedCardDate}</span>}
+                    {isBlog && <span>{formattedBlogCardDate()}</span>}
+                    {isFlexCard && showDateOnFooter && !endDate&& <span>{formattedFlexCardDate()}</span>}
                     <Group renderList={left} onFocus={onFocus} />
                 </div>
                 }

--- a/react/src/js/components/Consonant/Cards/CardFooter/CardFooter.jsx
+++ b/react/src/js/components/Consonant/Cards/CardFooter/CardFooter.jsx
@@ -156,7 +156,7 @@ const CardFooter = (props) => {
                     <Group renderList={left} onFocus={onFocus} />
                 </div>
                 }
-                {shouldRenderCenter &&
+                {shouldRenderCenter && !hideCTA &&
                 <div
                     className="consonant-CardFooter-cell consonant-CardFooter-cell--center">
                     <Group renderList={center} tabIndex={tabIndex} onFocus={onFocus} />

--- a/react/src/js/components/Consonant/Cards/CardFooter/CardFooter.jsx
+++ b/react/src/js/components/Consonant/Cards/CardFooter/CardFooter.jsx
@@ -144,7 +144,7 @@ const CardFooter = (props) => {
             return `${String(date.getMonth() + 1)}/${String(date.getDate())}/${date.getFullYear()}`;
         }
         return '';
-    }
+    };
 
     // Format date for blog card mm-dd-yyyy
     const formattedBlogCardDate = () => {
@@ -159,7 +159,7 @@ const CardFooter = (props) => {
                 .padStart(2, '0')}-${dateObj.getFullYear()}`;
         }
         return '';
-    }
+    };
     
     return (
         <div
@@ -172,7 +172,7 @@ const CardFooter = (props) => {
                 <div
                     className="consonant-CardFooter-cell consonant-CardFooter-cell--left">
                     {isBlog && <span>{formattedBlogCardDate()}</span>}
-                    {isFlexCard && showDateOnFooter && !endDate&& <span>{formattedFlexCardDate()}</span>}
+                    {isFlexCard && showDateOnFooter && !endDate && <span>{formattedFlexCardDate()}</span>}
                     <Group renderList={left} onFocus={onFocus} />
                 </div>
                 }

--- a/react/src/js/components/Consonant/Cards/FlexCard.jsx
+++ b/react/src/js/components/Consonant/Cards/FlexCard.jsx
@@ -108,7 +108,7 @@ const FlexCard = () => {
                     showText
                     highlightedDescription={highlightedDescription}
                     description={showDescription ? description : ''} />
-                {!hideCTA && showFooter &&
+                {showFooter &&
                 footer.map(footerItem => (
                     <CardFooter
                         divider={renderDivider || footerItem.divider}
@@ -130,7 +130,7 @@ const FlexCard = () => {
                         isBlog={false} />
                 ))}
             </div>
-            {(renderOverlay || hideCTA) &&
+            {(renderOverlay) &&
             <LinkBlocker
                 target={linkBlockerTarget}
                 link={overlay}

--- a/react/src/js/components/Consonant/Cards/FlexCard.jsx
+++ b/react/src/js/components/Consonant/Cards/FlexCard.jsx
@@ -20,7 +20,7 @@ const FlexCard = () => {
         highlightedTitle, title, headingAria, headingLevel,
         highlightedDescription, description,
         parseMarkDown,
-        footer, renderDivider, cardDate, startDate, endDate,
+        footer, renderDivider, cardDate, startDate, endDate, staticDate,
         extendFooterData, altCtaUsed, hideOnDemandDates,
         linkBlockerTarget, overlay, ctaText,
         onFocus, tabIndex, ariaHidden,
@@ -32,9 +32,10 @@ const FlexCard = () => {
     let showDetails = !(flexCardOptions?.hideDetails === true);
     const showTitle = !(flexCardOptions?.hideTitle === true);
     const showDescription = !(flexCardOptions?.hideDescription === true);
-    const showFooter = !(flexCardOptions?.hideFooter === true);
     const textSize = flexCardOptions?.textSize || '';
     const textSizeClass = textSize === 'text-large' ? 'text-large' : '';
+    const showDateOnFooter = flexCardOptions?.showDateOnFooter === true;
+    const showFooter = !hideCTA || showDateOnFooter || endDate;
 
     const getConfig = useConfig();
     const detailsTextOption = getConfig('collection', 'detailsTextOption');
@@ -121,13 +122,16 @@ const FlexCard = () => {
                         cardDate={new Date(cardDate)}
                         startDate={startDate}
                         endDate={endDate}
+                        staticDate={staticDate}
                         cardStyle="flex-card"
                         onFocus={onFocus}
                         title={title}
                         tabIndex={tabIndex}
                         renderOverlay={renderOverlay}
                         hideCTA={hideCTA}
-                        isBlog={false} />
+                        isBlog={false}
+                        isFlexCard={true}
+                        showDateOnFooter={showDateOnFooter} />
                 ))}
             </div>
             {(renderOverlay) &&

--- a/react/src/js/components/Consonant/Cards/FlexCard.jsx
+++ b/react/src/js/components/Consonant/Cards/FlexCard.jsx
@@ -20,7 +20,7 @@ const FlexCard = () => {
         highlightedTitle, title, headingAria, headingLevel,
         highlightedDescription, description,
         parseMarkDown,
-        footer, renderDivider, cardDate, startDate, endDate, staticDate,
+        footer, renderDivider, cardDate, startDate, endDate,
         extendFooterData, altCtaUsed, hideOnDemandDates,
         linkBlockerTarget, overlay, ctaText,
         onFocus, tabIndex, ariaHidden,

--- a/react/src/js/components/Consonant/Cards/FlexCard.jsx
+++ b/react/src/js/components/Consonant/Cards/FlexCard.jsx
@@ -122,7 +122,6 @@ const FlexCard = () => {
                         cardDate={new Date(cardDate)}
                         startDate={startDate}
                         endDate={endDate}
-                        staticDate={staticDate}
                         cardStyle="flex-card"
                         onFocus={onFocus}
                         title={title}

--- a/react/src/js/components/Consonant/Cards/__tests__/Flex.spec.js
+++ b/react/src/js/components/Consonant/Cards/__tests__/Flex.spec.js
@@ -92,17 +92,6 @@ describe(`Consonant/Card/${cardStyle}`, () => {
         expect(textElement).toBeNull();
     });
 
-    test('should hide the card footer when hideFooter is true', () => {
-        renderCard({ cardStyle }, {
-            collection: {
-                flexCard: { hideFooter: true },
-            },
-        });
-
-        const footerElement = screen.queryByTestId('consonant-Card-footer');
-        expect(footerElement).toBeNull();
-    });
-
     test('should apply the text-center class to the card when textAlign is text-center', () => {
         renderCard({ cardStyle }, {
             collection: {
@@ -191,22 +180,45 @@ describe(`Consonant/Card/${cardStyle}`, () => {
         expect(screen.queryByTestId('consonant-Card-label-product-info')).toBeNull();
     });
 
-    test('should render a link blocker when hideCTA is true', () => {
-        const { wrapper } = renderCard({
-            cardStyle,
-            hideCTA: true,
-            overlayLink: 'https://www.some-url.com',
-        });
-
-        const blocker = wrapper.container.querySelector('.consonant-LinkBlocker');
-        expect(blocker).not.toBeNull();
-    });
-
     test('should render a card title with a heading role and aria-level', () => {
         renderCard({ cardStyle });
 
         const titleElement = screen.getByTestId('consonant-Card-title');
         expect(titleElement).toHaveAttribute('aria-level');
+    });
+
+    describe('showDateOnFooter', () => {
+        const cardDate = '2024-01-15T12:00:00.000Z';
+
+        test('should render the card date in the footer when showDateOnFooter is true', () => {
+            renderCard({ cardStyle, cardDate }, {
+                collection: {
+                    flexCard: { showDateOnFooter: true },
+                },
+            });
+
+            expect(screen.getByText('01-15-2024')).toBeInTheDocument();
+        });
+
+        test('should not render the card date in the footer when showDateOnFooter is false', () => {
+            renderCard({ cardStyle, cardDate }, {
+                collection: {
+                    flexCard: { showDateOnFooter: false },
+                },
+            });
+
+            expect(screen.queryByText('01-15-2024')).toBeNull();
+        });
+
+        test('should not render the card date in the footer when an endDate is set', () => {
+            renderCard({ cardStyle, cardDate, endDate: '2024-02-01T12:00:00.000Z' }, {
+                collection: {
+                    flexCard: { showDateOnFooter: true },
+                },
+            });
+
+            expect(screen.queryByText('01-15-2024')).toBeNull();
+        });
     });
 
     // Accessibility tests with jest-axe

--- a/react/src/js/components/Consonant/Cards/__tests__/Flex.spec.js
+++ b/react/src/js/components/Consonant/Cards/__tests__/Flex.spec.js
@@ -1,238 +1,276 @@
-import { screen } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import { screen } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
 
-import Card from '../Card';
+import Card from "../Card";
 
-import { DEFAULT_PROPS_FLEX } from '../../Testing/Constants/Card';
+import { DEFAULT_PROPS_FLEX } from "../../Testing/Constants/Card";
 
-import setup from '../../Testing/Utils/Settings';
-import { testA11yForConfigs } from '../../Testing/Utils/a11yTest';
+import setup from "../../Testing/Utils/Settings";
+import { testA11yForConfigs } from "../../Testing/Utils/a11yTest";
 
 const renderCard = setup(Card, DEFAULT_PROPS_FLEX, { wrapInList: true });
 
-const cardStyle = 'flex-card';
+const cardStyle = "flex-card";
 
 describe(`Consonant/Card/${cardStyle}`, () => {
-    test('should be able to render a card header', () => {
-        renderCard({ cardStyle });
+  test("should be able to render a card header", () => {
+    renderCard({ cardStyle });
 
-        const headerElement = screen.queryByTestId('consonant-Card-header');
-        expect(headerElement).not.toBeNull();
-    });
+    const headerElement = screen.queryByTestId("consonant-Card-header");
+    expect(headerElement).not.toBeNull();
+  });
 
-    test('should be able to render a detail/eyebrow text', () => {
-        renderCard({ cardStyle });
+  test("should be able to render a detail/eyebrow text", () => {
+    renderCard({ cardStyle });
 
-        const labelElement = screen.queryByTestId('consonant-Card-label');
-        expect(labelElement).not.toBeNull();
-    });
+    const labelElement = screen.queryByTestId("consonant-Card-label");
+    expect(labelElement).not.toBeNull();
+  });
 
-    test('should be able to render a card title', () => {
-        renderCard({ cardStyle });
+  test("should be able to render a card title", () => {
+    renderCard({ cardStyle });
 
-        const titleElement = screen.queryByTestId('consonant-Card-title');
-        expect(titleElement).not.toBeNull();
-    });
+    const titleElement = screen.queryByTestId("consonant-Card-title");
+    expect(titleElement).not.toBeNull();
+  });
 
-    test('should be able to render a card text', () => {
-        renderCard({ cardStyle });
+  test("should be able to render a card text", () => {
+    renderCard({ cardStyle });
 
-        const textElement = screen.queryByTestId('consonant-Card-text');
-        expect(textElement).not.toBeNull();
-    });
+    const textElement = screen.queryByTestId("consonant-Card-text");
+    expect(textElement).not.toBeNull();
+  });
 
-    test('should be able to render a card footer', () => {
-        renderCard({ cardStyle });
+  test("should be able to render a card footer", () => {
+    renderCard({ cardStyle });
 
-        const footerElement = screen.queryByTestId('consonant-Card-footer');
-        expect(footerElement).not.toBeNull();
-    });
+    const footerElement = screen.queryByTestId("consonant-Card-footer");
+    expect(footerElement).not.toBeNull();
+  });
 
-    test('should hide the card header when imageOption is hidden', () => {
-        renderCard({ cardStyle }, {
-            collection: {
-                flexCard: { imageOption: 'hidden' },
-            },
-        });
-
-        const headerElement = screen.queryByTestId('consonant-Card-header');
-        expect(headerElement).toBeNull();
-    });
-
-    test('should apply the imageOption class to the card header', () => {
-        renderCard({ cardStyle }, {
-            collection: {
-                flexCard: { imageOption: 'image-small-center' },
-            },
-        });
-
-        const headerElement = screen.getByTestId('consonant-Card-header');
-        expect(headerElement).toHaveClass('image-small-center');
-    });
-
-    test('should hide the detail text when hideDetails is true', () => {
-        renderCard({ cardStyle }, {
-            collection: {
-                flexCard: { hideDetails: true },
-            },
-        });
-
-        const labelElement = screen.queryByTestId('consonant-Card-label');
-        expect(labelElement).toBeNull();
-    });
-
-    test('should hide the card description when hideDescription is true', () => {
-        renderCard({ cardStyle }, {
-            collection: {
-                flexCard: { hideDescription: true },
-            },
-        });
-
-        const textElement = screen.queryByTestId('consonant-Card-text');
-        expect(textElement).toBeNull();
-    });
-
-    test('should apply the text-center class to the card when textAlign is text-center', () => {
-        renderCard({ cardStyle }, {
-            collection: {
-                flexCard: { textAlign: 'text-center' },
-            },
-        });
-
-        const cardElement = screen.getByTestId('consonant-Card');
-        expect(cardElement).toHaveClass('text-center');
-    });
-
-    test('should apply the text-large class to the card when textSize is text-large', () => {
-        renderCard({ cardStyle }, {
-            collection: {
-                flexCard: { textSize: 'text-large' },
-            },
-        });
-
-        const cardElement = screen.getByTestId('consonant-Card');
-        expect(cardElement).toHaveClass('text-large');
-    });
-
-    test('should render product info when detailsTextOption is productName and a matching product exists', () => {
-        renderCard({
-            cardStyle,
-            contentArea: { detailText: 'some details' },
-        }, {
-            collection: {
-                detailsTextOption: 'productName',
-            },
-            products: {
-                acrobat: {
-                    tagID: 'some details',
-                    title: 'Acrobat',
-                    tagImage: 'https://example.com/acrobat-icon.svg',
-                },
-            },
-        });
-
-        const productTitle = screen.getByText('Acrobat');
-        expect(productTitle).toBeInTheDocument();
-    });
-
-    test('should not render the detail text when product info is shown', () => {
-        renderCard({
-            cardStyle,
-            contentArea: {
-                detailText: 'some details',
-            },
-        }, {
-            collection: {
-                detailsTextOption: 'productName',
-            },
-            products: {
-                acrobat: {
-                    tagID: 'some details',
-                    title: 'Acrobat',
-                    tagImage: 'https://example.com/acrobat-icon.svg',
-                },
-            },
-        });
-
-        const detailText = screen.queryByText('some details');
-        expect(detailText).toBeNull();
-    });
-
-    test('should hide the detail text when detailsTextOption is productName but no product matches', () => {
-        renderCard({
-            cardStyle,
-            contentArea: { detailText: 'some details' },
-        }, {
-            collection: {
-                detailsTextOption: 'productName',
-            },
-            products: {
-                acrobat: {
-                    tagID: 'unrelated-tag',
-                    title: 'Acrobat',
-                    tagImage: 'https://example.com/acrobat-icon.svg',
-                },
-            },
-        });
-
-        expect(screen.queryByText('some details')).toBeNull();
-        expect(screen.queryByTestId('consonant-Card-label')).toBeNull();
-        expect(screen.queryByTestId('consonant-Card-label-product-info')).toBeNull();
-    });
-
-    test('should render a card title with a heading role and aria-level', () => {
-        renderCard({ cardStyle });
-
-        const titleElement = screen.getByTestId('consonant-Card-title');
-        expect(titleElement).toHaveAttribute('aria-level');
-    });
-
-    describe('showDateOnFooter', () => {
-        const cardDate = '2024-01-15T12:00:00.000Z';
-
-        test('should render the card date in the footer when showDateOnFooter is true', () => {
-            renderCard({ cardStyle, cardDate }, {
-                collection: {
-                    flexCard: { showDateOnFooter: true },
-                },
-            });
-
-            expect(screen.getByText('01-15-2024')).toBeInTheDocument();
-        });
-
-        test('should not render the card date in the footer when showDateOnFooter is false', () => {
-            renderCard({ cardStyle, cardDate }, {
-                collection: {
-                    flexCard: { showDateOnFooter: false },
-                },
-            });
-
-            expect(screen.queryByText('01-15-2024')).toBeNull();
-        });
-
-        test('should not render the card date in the footer when an endDate is set', () => {
-            renderCard({ cardStyle, cardDate, endDate: '2024-02-01T12:00:00.000Z' }, {
-                collection: {
-                    flexCard: { showDateOnFooter: true },
-                },
-            });
-
-            expect(screen.queryByText('01-15-2024')).toBeNull();
-        });
-    });
-
-    // Accessibility tests with jest-axe
-    testA11yForConfigs(renderCard, [
-        {
-            name: 'Default flex card',
-            props: { cardStyle },
+  test("should hide the card header when imageOption is hidden", () => {
+    renderCard(
+      { cardStyle },
+      {
+        collection: {
+          flexCard: { imageOption: "hidden" },
         },
-        {
-            name: 'Flex card with hidden image',
-            props: {
-                cardStyle,
-                overlays: {},
-            },
+      }
+    );
+
+    const headerElement = screen.queryByTestId("consonant-Card-header");
+    expect(headerElement).toBeNull();
+  });
+
+  test("should apply the imageOption class to the card header", () => {
+    renderCard(
+      { cardStyle },
+      {
+        collection: {
+          flexCard: { imageOption: "image-small-center" },
         },
-    ]);
+      }
+    );
+
+    const headerElement = screen.getByTestId("consonant-Card-header");
+    expect(headerElement).toHaveClass("image-small-center");
+  });
+
+  test("should hide the detail text when hideDetails is true", () => {
+    renderCard(
+      { cardStyle },
+      {
+        collection: {
+          flexCard: { hideDetails: true },
+        },
+      }
+    );
+
+    const labelElement = screen.queryByTestId("consonant-Card-label");
+    expect(labelElement).toBeNull();
+  });
+
+  test("should hide the card description when hideDescription is true", () => {
+    renderCard(
+      { cardStyle },
+      {
+        collection: {
+          flexCard: { hideDescription: true },
+        },
+      }
+    );
+
+    const textElement = screen.queryByTestId("consonant-Card-text");
+    expect(textElement).toBeNull();
+  });
+
+  test("should apply the text-center class to the card when textAlign is text-center", () => {
+    renderCard(
+      { cardStyle },
+      {
+        collection: {
+          flexCard: { textAlign: "text-center" },
+        },
+      }
+    );
+
+    const cardElement = screen.getByTestId("consonant-Card");
+    expect(cardElement).toHaveClass("text-center");
+  });
+
+  test("should apply the text-large class to the card when textSize is text-large", () => {
+    renderCard(
+      { cardStyle },
+      {
+        collection: {
+          flexCard: { textSize: "text-large" },
+        },
+      }
+    );
+
+    const cardElement = screen.getByTestId("consonant-Card");
+    expect(cardElement).toHaveClass("text-large");
+  });
+
+  test("should render product info when detailsTextOption is productName and a matching product exists", () => {
+    renderCard(
+      {
+        cardStyle,
+        contentArea: { detailText: "some details" },
+      },
+      {
+        collection: {
+          detailsTextOption: "productName",
+        },
+        products: {
+          acrobat: {
+            tagID: "some details",
+            title: "Acrobat",
+            tagImage: "https://example.com/acrobat-icon.svg",
+          },
+        },
+      }
+    );
+
+    const productTitle = screen.getByText("Acrobat");
+    expect(productTitle).toBeInTheDocument();
+  });
+
+  test("should not render the detail text when product info is shown", () => {
+    renderCard(
+      {
+        cardStyle,
+        contentArea: {
+          detailText: "some details",
+        },
+      },
+      {
+        collection: {
+          detailsTextOption: "productName",
+        },
+        products: {
+          acrobat: {
+            tagID: "some details",
+            title: "Acrobat",
+            tagImage: "https://example.com/acrobat-icon.svg",
+          },
+        },
+      }
+    );
+
+    const detailText = screen.queryByText("some details");
+    expect(detailText).toBeNull();
+  });
+
+  test("should hide the detail text when detailsTextOption is productName but no product matches", () => {
+    renderCard(
+      {
+        cardStyle,
+        contentArea: { detailText: "some details" },
+      },
+      {
+        collection: {
+          detailsTextOption: "productName",
+        },
+        products: {
+          acrobat: {
+            tagID: "unrelated-tag",
+            title: "Acrobat",
+            tagImage: "https://example.com/acrobat-icon.svg",
+          },
+        },
+      }
+    );
+
+    expect(screen.queryByText("some details")).toBeNull();
+    expect(screen.queryByTestId("consonant-Card-label")).toBeNull();
+    expect(
+      screen.queryByTestId("consonant-Card-label-product-info")
+    ).toBeNull();
+  });
+
+  test("should render a card title with a heading role and aria-level", () => {
+    renderCard({ cardStyle });
+
+    const titleElement = screen.getByTestId("consonant-Card-title");
+    expect(titleElement).toHaveAttribute("aria-level");
+  });
+
+  describe("showDateOnFooter", () => {
+    const cardDate = "2024-01-15T12:00:00.000Z";
+
+    test("should render the card date in the footer when showDateOnFooter is true", () => {
+      renderCard(
+        { cardStyle, cardDate },
+        {
+          collection: {
+            flexCard: { showDateOnFooter: true },
+          },
+        }
+      );
+
+      expect(screen.getByText("1/15/2024")).toBeInTheDocument();
+    });
+
+    test("should not render the card date in the footer when showDateOnFooter is false", () => {
+      renderCard(
+        { cardStyle, cardDate },
+        {
+          collection: {
+            flexCard: { showDateOnFooter: false },
+          },
+        }
+      );
+
+      expect(screen.queryByText("1/15/2024")).toBeNull();
+    });
+
+    test("should not render the card date in the footer when an endDate is set", () => {
+      renderCard(
+        { cardStyle, cardDate, endDate: "2024-02-01T12:00:00.000Z" },
+        {
+          collection: {
+            flexCard: { showDateOnFooter: true },
+          },
+        }
+      );
+
+      expect(screen.queryByText("1/15/2024")).toBeNull();
+    });
+  });
+
+  // Accessibility tests with jest-axe
+  testA11yForConfigs(renderCard, [
+    {
+      name: "Default flex card",
+      props: { cardStyle },
+    },
+    {
+      name: "Flex card with hidden image",
+      props: {
+        cardStyle,
+        overlays: {},
+      },
+    },
+  ]);
 });


### PR DESCRIPTION

## Summary
- Add `showDateOnFooter` flex-card option to render the card date in the footer (suppressed when an `endDate` is present).
- Support inline markup in flex-card descriptions: line breaks (`\n` → `<br/>`) and CTA links via `{link:cta1}` / `{link:cta2}` tokens resolved from footer CTA data.
- Add a `hidden` value for `detailsTextOption` to blank out the detail text.
- Decouple footer visibility from `hideCTA`: the footer now renders when a date or end date is shown, and the CTA center cell is hidden via `hideCTA` instead of dropping the whole footer.
- Refactor flex-card LESS: relocate `rounded-corners`, add footer/text spacing rules, and normalize leading `<br/>`/paragraph margins.

## Jira Ticket
Resolves: 
- [MWPW-193974](https://jira.corp.adobe.com/browse/MWPW-193974)
- [MWPW-199546](https://jira.corp.adobe.com/browse/MWPW-199546)
- [MWPW-200284](https://jira.corp.adobe.com/browse/MWPW-200284)

## Changes
- `react/src/js/components/Consonant/Cards/Card.jsx` — add `getCtaLink` helper and `parseLinks`; extend `parseMarkDown` to convert newlines to `<br/>` and expand `{link:cta*}` tokens; add `detailsTextOption === 'hidden'` case; reformat `cardData` memo object.
- `react/src/js/components/Consonant/Cards/FlexCard.jsx` — compute `showFooter` from `hideCTA`/`showDateOnFooter`/`endDate`; pass `staticDate`, `isFlexCard`, and `showDateOnFooter` to `CardFooter`; only render `LinkBlocker` on `renderOverlay`.
- `react/src/js/components/Consonant/Cards/CardFooter/CardFooter.jsx` — accept `staticDate`, `isFlexCard`, `showDateOnFooter`; render left-cell date for flex cards (no `endDate`); gate center cell on `!hideCTA`.
- `less/components/consonant/cards/flex.less` — relocate `rounded-corners`, add `consonant-Card-text` / `consonant-CardFooter` spacing rules, and reset first-child `<br/>`/paragraph margins.
- `react/src/js/components/Consonant/Cards/__tests__/Flex.spec.js` — remove obsolete `hideFooter`/`hideCTA` link-blocker tests; add `showDateOnFooter` test suite.

## Test plan
- [x] With `flexCard.showDateOnFooter: true` and a `cardDate`, the formatted date renders in the footer left cell.
- [x] With an `endDate` set, the footer date is suppressed even when `showDateOnFooter` is true.
- [x] Descriptions containing `\n` render line breaks, and `{link:cta1}`/`{link:cta2}` resolve to the corresponding footer CTA hrefs/text.
- [x] `detailsTextOption: 'hidden'` blanks the detail text.
- [x] `hideCTA` hides the CTA center cell but the footer still renders when a date is shown.
- [x] Unit tests added/updated

## Screenshot
<img width="1671" height="969" alt="Screenshot 2026-07-14 at 6 20 54 PM" src="https://github.com/user-attachments/assets/1ccb45c4-7a6b-4e65-af67-618f3f7cf86a" />


