### PR TITLE
ci(mwpw-201313): add majority-vote review-score merge gate

### DIFF
--- a/.github/workflows/review-score.yml
+++ b/.github/workflows/review-score.yml
@@ -1,0 +1,51 @@
+name: Review Score Gate
+"on":
+  pull_request:
+    types: [opened, reopened, synchronize]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+permissions:
+  pull-requests: read
+jobs:
+  review-score-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Review score gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          cat > "$RUNNER_TEMP/review-score.js" <<'SCRIPT'
+          const { execSync } = require('child_process');
+          const ALLOWED_VOTERS = [
+            'auniverseaway', 'chrischrischris', 'cmiqueo', 'honstar',
+            'jedjedjedM', 'jenssingler', 'raissanjay', 'sanrai',
+            'sheridansunier', 'shkhan91', 'sukamat',
+          ];
+          const REQUIRED_SCORE = 1;   // net (approvals - blocks); a tie fails, 2 approvals clear 1 block
+          const repo = process.env.REPO;
+          const pr = process.env.PR_NUMBER;
+          const author = (process.env.PR_AUTHOR || '').toLowerCase();
+          if (!pr) { console.log('no pull_request context; skipping'); process.exit(0); }
+          const voters = new Set(ALLOWED_VOTERS.map(function (s) { return s.toLowerCase(); }));
+          const raw = execSync('gh api "repos/' + repo + '/pulls/' + pr + '/reviews?per_page=100" --paginate',
+            { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+          const reviews = JSON.parse(raw);
+          const latest = new Map();
+          for (const r of reviews) {
+            const l = ((r.user && r.user.login) || '').toLowerCase();
+            if (!l || l === author || !voters.has(l)) continue;
+            if (r.state === 'APPROVED' || r.state === 'CHANGES_REQUESTED') latest.set(l, r.state);
+            else if (r.state === 'DISMISSED') latest.delete(l);
+          }
+          let a = 0, b = 0;
+          for (const s of latest.values()) { if (s === 'APPROVED') a++; else b++; }
+          const score = a - b;
+          const pass = score >= REQUIRED_SCORE;
+          console.log('score ' + score + ' (' + a + ' approve, ' + b + ' block), need >= ' + REQUIRED_SCORE);
+          if (!pass) { console.error('BLOCKED: review score below threshold'); process.exit(1); }
+          console.log('PASS');
+          SCRIPT
+          node "$RUNNER_TEMP/review-score.js"


### PR DESCRIPTION
## Majority-vote review-score merge gate

Adds a GitHub Actions workflow that posts a required status check, `review-score-gate`, gating merges on a simple review score.

**Rule:** among an allowlist of voters, `score = approvals - change_requests`. Merge is allowed when `score >= 1`.
- The PR author's own review never counts.
- Each voter's latest decisive review is used; a `DISMISSED` review clears that voter's vote; `COMMENTED` never clears one.
- A tie fails (1 approve vs 1 block blocks); you need 2 approvals to clear 1 block.

**Why:** `main` currently has no protection, so a PR can be merged with zero approvals or over an objection. This closes that gap with a lightweight, majority-style gate suited to a small team.

**Implementation notes:**
- Uses only the pre-installed `gh` CLI + node (no marketplace action), so there is nothing to download and no transient `codeload` 429s to flake a required check.
- Needs `pull-requests: read` only.
- Must live on `main` for the `pull_request_review` trigger to react to approvals.

**Follow-up after merge:** a branch ruleset on `main` will mark `review-score-gate` required (alongside `Adobe CLA Signed?`, `check-build`, `check-coverage-thresholds`, `run-unit-tests`), with an empty bypass list.

Edit the `ALLOWED_VOTERS` list in the workflow to manage who can vote (that change is itself a PR).
