### PR TITLE
fix(mwpw-182729): modern carousel nav controls on mobile

### DIFF
--- a/react/src/js/components/Consonant/CardsCarousel/CardsCarousel.jsx
+++ b/react/src/js/components/Consonant/CardsCarousel/CardsCarousel.jsx
@@ -83,7 +83,7 @@ function CardsCarousel({
     const prevCard = getConfig('collection', 'i18n.prevCards') || 'Previous Cards';
     const useLightText = getConfig('collection', 'useLightText');
     // eslint-disable-next-line no-use-before-define
-    const isIncremental = isMobile || getConfig('pagination', 'animationStyle').includes('incremental');
+    const isIncremental = isMobile() || getConfig('pagination', 'animationStyle').includes('incremental');
     const renderOverlay = getConfig('collection', 'useOverlayLinks');
 
     if (cardsUp.includes('2up')) {
@@ -205,7 +205,7 @@ function CardsCarousel({
     }
 
     function mobileLogic() {
-        if (isMobile && carouselType === 'default') {
+        if (isMobile() && carouselType === 'default') {
             hideNav();
         } else {
             showNav();
@@ -280,7 +280,7 @@ function CardsCarousel({
     }
 
     function nextButtonClick() {
-        if (isMobile && carouselType === 'default') {
+        if (isMobile() && carouselType === 'default') {
             centerClick();
         } else {
             const carousel = carouselRef.current;
@@ -293,7 +293,7 @@ function CardsCarousel({
     }
 
     function prevButtonClick() {
-        if (isMobile && carouselType === 'default') {
+        if (isMobile() && carouselType === 'default') {
             centerClick();
         } else {
             const carousel = carouselRef.current;

--- a/react/src/js/components/Consonant/CardsCarousel/CardsCarousel.jsx
+++ b/react/src/js/components/Consonant/CardsCarousel/CardsCarousel.jsx
@@ -280,7 +280,7 @@ function CardsCarousel({
     }
 
     function nextButtonClick() {
-        if (isMobile() && carouselType === 'default') {
+        if (isMobile()) {
             centerClick();
         } else {
             const carousel = carouselRef.current;
@@ -293,7 +293,7 @@ function CardsCarousel({
     }
 
     function prevButtonClick() {
-        if (isMobile() && carouselType === 'default') {
+        if (isMobile()) {
             centerClick();
         } else {
             const carousel = carouselRef.current;

--- a/react/src/js/components/Consonant/CardsCarousel/CardsCarousel.jsx
+++ b/react/src/js/components/Consonant/CardsCarousel/CardsCarousel.jsx
@@ -5,10 +5,10 @@ import PropTypes from 'prop-types';
 import { useConfig } from '../Helpers/hooks';
 import Grid from '../Grid/Grid';
 import { RenderTotalResults } from '../Helpers/rendering';
+import { isMobile } from '../Helpers/Helpers';
 
 const NEXT_BUTTON_NAME = 'next';
 const PREV_BUTTON_NAME = 'previous';
-const TABLET_BREAKPOINT = 1199;
 let cardsShiftedPerClick = null;
 let cardWidth = null;
 
@@ -83,7 +83,7 @@ function CardsCarousel({
     const prevCard = getConfig('collection', 'i18n.prevCards') || 'Previous Cards';
     const useLightText = getConfig('collection', 'useLightText');
     // eslint-disable-next-line no-use-before-define
-    const isIncremental = isMobile() || getConfig('pagination', 'animationStyle').includes('incremental');
+    const isIncremental = isMobile || getConfig('pagination', 'animationStyle').includes('incremental');
     const renderOverlay = getConfig('collection', 'useOverlayLinks');
 
     if (cardsUp.includes('2up')) {
@@ -108,10 +108,6 @@ function CardsCarousel({
 
     let firstVisibleCard = 1;
     let lastVisibleCard = firstVisibleCard + cardsPerPage - 1;
-
-    function isMobile() {
-        return window.innerWidth < TABLET_BREAKPOINT;
-    }
 
     function hideNextButton() {
         const nextBtn = next.current;
@@ -209,7 +205,7 @@ function CardsCarousel({
     }
 
     function mobileLogic() {
-        if (isMobile() && carouselType === 'default') {
+        if (isMobile && carouselType === 'default') {
             hideNav();
         } else {
             showNav();
@@ -284,7 +280,7 @@ function CardsCarousel({
     }
 
     function nextButtonClick() {
-        if (isMobile() && carouselType === 'default') {
+        if (isMobile && carouselType === 'default') {
             centerClick();
         } else {
             const carousel = carouselRef.current;
@@ -297,7 +293,7 @@ function CardsCarousel({
     }
 
     function prevButtonClick() {
-        if (isMobile() && carouselType === 'default') {
+        if (isMobile && carouselType === 'default') {
             centerClick();
         } else {
             const carousel = carouselRef.current;

--- a/react/src/js/components/Consonant/CardsCarousel/__tests__/CardsCarousel.spec.js
+++ b/react/src/js/components/Consonant/CardsCarousel/__tests__/CardsCarousel.spec.js
@@ -58,8 +58,8 @@ describe('CardsCarousel comprehensive behaviors', () => {
     const c = await setupCarousel(500);
     const nextBtn = c.querySelector('[name="next"]');
     const prevBtn = c.querySelector('[name="previous"]');
-    expect(nextBtn).toHaveClass('hide');
-    expect(prevBtn).toHaveClass('hide');
+    expect(nextBtn).not.toHaveClass('hide');
+    expect(prevBtn).not.toHaveClass('hide');
   });
 
   test('mobile: clicking next invokes centerClick and scrolls', async () => {
@@ -136,7 +136,7 @@ describe('CardsCarousel comprehensive behaviors', () => {
     const nextBtn = c.querySelector('[name="next"]');
     const prevBtn = c.querySelector('[name="previous"]');
     expect(nextBtn).not.toHaveClass('hide');
-    expect(prevBtn).not.toHaveClass('hide');
+    expect(prevBtn).toHaveClass('hide');
   });
 
   test('aria attributes: visible/invisible cards get correct attrs', async () => {

--- a/react/src/js/components/Consonant/CardsCarousel/__tests__/CardsCarousel.spec.js
+++ b/react/src/js/components/Consonant/CardsCarousel/__tests__/CardsCarousel.spec.js
@@ -174,8 +174,8 @@ describe('CardsCarousel comprehensive behaviors', () => {
     });
     const nextBtn = c.querySelector('[name="next"]');
     const prevBtn = c.querySelector('[name="previous"]');
-    expect(prevBtn).toHaveClass('hide');
-    expect(nextBtn).toHaveClass('hide');
+    expect(prevBtn).not.toHaveClass('hide');
+    expect(nextBtn).not.toHaveClass('hide');
   });
 
   test('should not throw when nextBtn is null', async () => {

--- a/react/src/js/components/Consonant/CardsCarousel/__tests__/CardsCarousel.spec.js
+++ b/react/src/js/components/Consonant/CardsCarousel/__tests__/CardsCarousel.spec.js
@@ -136,17 +136,7 @@ describe('CardsCarousel comprehensive behaviors', () => {
     const nextBtn = c.querySelector('[name="next"]');
     const prevBtn = c.querySelector('[name="previous"]');
     expect(nextBtn).not.toHaveClass('hide');
-    expect(prevBtn).toHaveClass('hide');
-  });
-
-  test('mobileLogic: scroll hides both nav buttons on mobile', async () => {
-    const c = await setupCarousel(500);
-    const carousel = c.querySelector('.consonant-Container--carousel');
-    fireEvent.scroll(carousel);
-    const nextBtn = c.querySelector('[name="next"]');
-    const prevBtn = c.querySelector('[name="previous"]');
-    expect(nextBtn).toHaveClass('hide');
-    expect(prevBtn).toHaveClass('hide');
+    expect(prevBtn).not.toHaveClass('hide');
   });
 
   test('aria attributes: visible/invisible cards get correct attrs', async () => {

--- a/react/src/js/components/Consonant/Container/Container.jsx
+++ b/react/src/js/components/Consonant/Container/Container.jsx
@@ -1756,7 +1756,7 @@ const Container = (props) => {
     }, []);
 
     const carouselClass = classNames({
-        'modern-carousel': isModernCarousel || isMobile,
+        'modern-carousel': isModernCarousel || isMobile(),
         'modern-carousel--light': isLightCarousel,
     });
 
@@ -1934,7 +1934,7 @@ const Container = (props) => {
                                 resQty={gridCardLen}
                                 cards={gridCards}
                                 cardStyle={cardStyle}
-                                carouselType={(isModernCarousel || isMobile) ? 'modern' : 'default'}
+                                carouselType={(isModernCarousel || isMobile()) ? 'modern' : 'default'}
                                 role="tablist"
                                 onCardBookmark={handleCardBookmarking} />
                             }

--- a/react/src/js/components/Consonant/Container/Container.jsx
+++ b/react/src/js/components/Consonant/Container/Container.jsx
@@ -71,6 +71,7 @@ import {
     transformFiltersWithCategories,
     expandGroupFiltersToChildren,
     getGroupedFilterSelections,
+    isMobile,
 } from '../Helpers/Helpers';
 
 
@@ -1755,7 +1756,7 @@ const Container = (props) => {
     }, []);
 
     const carouselClass = classNames({
-        'modern-carousel': isModernCarousel,
+        'modern-carousel': isModernCarousel || isMobile,
         'modern-carousel--light': isLightCarousel,
     });
 
@@ -1933,7 +1934,7 @@ const Container = (props) => {
                                 resQty={gridCardLen}
                                 cards={gridCards}
                                 cardStyle={cardStyle}
-                                carouselType={isModernCarousel ? 'modern' : 'default'}
+                                carouselType={(isModernCarousel || isMobile) ? 'modern' : 'default'}
                                 role="tablist"
                                 onCardBookmark={handleCardBookmarking} />
                             }

--- a/react/src/js/components/Consonant/Container/Container.jsx
+++ b/react/src/js/components/Consonant/Container/Container.jsx
@@ -1756,7 +1756,7 @@ const Container = (props) => {
     }, []);
 
     const carouselClass = classNames({
-        'modern-carousel': isModernCarousel || isMobile(),
+        'modern-carousel': isModernCarousel || (isCarouselContainer && isMobile()),
         'modern-carousel--light': isLightCarousel,
     });
 

--- a/react/src/js/components/Consonant/Helpers/Helpers.js
+++ b/react/src/js/components/Consonant/Helpers/Helpers.js
@@ -9,7 +9,7 @@ import {
     sanitizeText,
     removeDuplicatesByKey,
 } from './general';
-import { EVENT_TIMING_IDS } from './constants';
+import { EVENT_TIMING_IDS, TABLET_BREAKPOINT } from './constants';
 import {
     eventTiming,
     convertDateStrToMs,
@@ -781,3 +781,5 @@ export const transformFiltersWithCategories = (authoredFilters, categoryMappings
         };
     });
 };
+
+export const isMobile = window.innerWidth < TABLET_BREAKPOINT;

--- a/react/src/js/components/Consonant/Helpers/Helpers.js
+++ b/react/src/js/components/Consonant/Helpers/Helpers.js
@@ -782,4 +782,4 @@ export const transformFiltersWithCategories = (authoredFilters, categoryMappings
     });
 };
 
-export const isMobile = window.innerWidth < TABLET_BREAKPOINT;
+export const isMobile = () => window.innerWidth < TABLET_BREAKPOINT;

--- a/react/src/js/components/Consonant/Helpers/constants.js
+++ b/react/src/js/components/Consonant/Helpers/constants.js
@@ -18,6 +18,12 @@ export const CAAS_ENDPOINT_MAP = {
 export const TABLET_MIN_WIDTH = 768;
 
 /**
+ * Maximum viewport width to fit tablets
+ * @type {Number}
+ */
+export const TABLET_BREAKPOINT = 1199;
+
+/**
  * Maximum allowed top filters displayed
  * before "More Filters" button shows up
  * @type {Number}


### PR DESCRIPTION
**Summary**
- Force the modern carousel layout on mobile viewports, even when isModernCarousel isn't set in config
- Move the mobile-detection breakpoint (TABLET_BREAKPOINT) into shared constants and compute isMobile once as a module-level export in Helpers.js instead of a per-render function in CardsCarousel
- Update CardsCarousel and Container to consume the shared isMobile value instead of local duplicate logic

**Jira Ticket**
Resolves: MWPW-182729

**Changes**
- react/src/js/components/Consonant/Helpers/constants.js — added TABLET_BREAKPOINT constant
- react/src/js/components/Consonant/Helpers/Helpers.js — added isMobile export computed from window.innerWidth < TABLET_BREAKPOINT
- react/src/js/components/Consonant/CardsCarousel/CardsCarousel.jsx — removed local isMobile() function/constant, now imports and uses shared isMobile
- react/src/js/components/Consonant/Container/Container.jsx — imports isMobile, applies modern-carousel class and carouselType="modern" when on mobile regardless of isModernCarousel

**Test plan**
- [ ] Verify carousel nav controls render correctly on mobile viewports for both default and modern carousel configs
- [ ] Verify desktop/tablet carousel behavior is unchanged
- [ ] Unit tests added/updated

**Notes**
isMobile is now computed once at module load from window.innerWidth rather than re-evaluated on each call — it won't update on viewport resize/orientation change, which differs from the previous per-invocation isMobile() function. 