### PR TITLE
feat(mwpw-0): probe B, new component with e2e only

### DIFF
--- a/e2e-tests/specs/probe.e2e.js
+++ b/e2e-tests/specs/probe.e2e.js
@@ -1,0 +1,5 @@
+describe('Probe enforcement gate', () => {
+    it('placeholder integration test for the gate probe', async () => {
+        expect(true).toBe(true);
+    });
+});

--- a/react/src/js/components/Consonant/Probe/ProbeBadge.jsx
+++ b/react/src/js/components/Consonant/Probe/ProbeBadge.jsx
@@ -1,0 +1,7 @@
+/**
+ * Temporary probe component. Exists only to exercise the test-enforcement
+ * gate from PR #568 with a real PR. Delete when the probe PR closes.
+ */
+const ProbeBadge = () => null;
+
+export default ProbeBadge;


### PR DESCRIPTION
End-to-end probe for the enforcement rules in #568. This PR contains the new test-enforcement.js (branched from that PR), so its own check-test-requirements job runs the new rules against a real GitHub file listing.

EXPECT: check-test-requirements FAILS with 'New feature components require unit tests'

Throwaway PR: close without merging once the check result is recorded.