### PR TITLE
fix(mwpw-203327): adds banner css to editorial card

### DIFF
--- a/less/components/consonant/cards/editorial.less
+++ b/less/components/consonant/cards/editorial.less
@@ -8,6 +8,37 @@
             height: 213px;
             background-size: cover;
             background-position: center;
+
+            .consonant-Card-banner {
+                position: absolute;
+                display: flex;
+                justify-content: flex-start;
+                max-width: 56%;
+                max-height: 70%;
+                top: 24px;
+                right: 0;
+                padding: 8px 13px;
+
+                .font(0.75rem, 1.0625rem, 700, @consonantBaseColor);
+
+                letter-spacing: 0.72px;
+                text-transform: uppercase;
+                border-top-left-radius: 4px;
+                border-bottom-left-radius: 4px;
+                z-index: 1;
+                background-color: @consonantBlue600;
+                user-select: none;
+                overflow-y: auto;
+
+                &IconWrapper {
+                    margin-right: 4px;
+
+                    img {
+                        width: 8px;
+                        height: 8px;
+                    }
+                }
+            }
         }
 
         .consonant-Card-content {
@@ -30,6 +61,37 @@
     .consonant-Card.consonant-editorial--open {
         .consonant-Card-header {
             border-radius: 16px;
+
+            .consonant-Card-banner {
+                position: absolute;
+                display: flex;
+                justify-content: flex-start;
+                max-width: 56%;
+                max-height: 70%;
+                top: 24px;
+                right: 0;
+                padding: 8px 13px;
+
+                .font(0.75rem, 1.0625rem, 700, @consonantBaseColor);
+
+                letter-spacing: 0.72px;
+                text-transform: uppercase;
+                border-top-left-radius: 4px;
+                border-bottom-left-radius: 4px;
+                z-index: 1;
+                background-color: @consonantBlue600;
+                user-select: none;
+                overflow-y: auto;
+
+                &IconWrapper {
+                    margin-right: 4px;
+
+                    img {
+                        width: 8px;
+                        height: 8px;
+                    }
+                }
+            }
         }
 
         .consonant-Card-content {


### PR DESCRIPTION
**Summary**

- Adds standard .consonant-Card-banner styling to the editorial card header (both default and --open states)
- Positions the banner absolutely in the top-right of the card image with rounded left corners, blue background, and uppercase bold text
- Adds a nested IconWrapper modifier for a small 8x8px icon with right margin

**Jira Ticket**
Resolves: https://jira.corp.adobe.com/browse/MWPW-203327

**Changes**
- less/components/consonant/cards/editorial.less — added banner CSS block (duplicated for .consonant-Card-header and .consonant-editorial--open .consonant-Card-header)

**Before**
<img width="393" height="490" alt="Screenshot 2026-08-06 at 11 43 50 AM" src="https://github.com/user-attachments/assets/5f754bee-4010-4068-bdcd-353ba238eae9" />

**After**
<img width="396" height="496" alt="Screenshot 2026-08-06 at 11 43 27 AM" src="https://github.com/user-attachments/assets/67bda88c-e8f2-4a48-8d79-a06a05c370cb" />

**Test plan**
- [x] Render an editorial card with banner data and confirm it displays top-right with correct color/typography
- [ ] Verify banner icon (if present) renders at 8x8px with correct spacing
- [x] Check both default and expanded (--open) card states render the banner consistently
- [x] Confirm no visual regression on editorial cards without a banner