### PR TITLE
feat(mwpw-198303): removes collection from page if there are no filtered cards to display

### DIFF
--- a/react/src/js/components/Consonant/CardsCarousel/CardsCarousel.jsx
+++ b/react/src/js/components/Consonant/CardsCarousel/CardsCarousel.jsx
@@ -320,7 +320,7 @@ function CardsCarousel({
     useEffect(() => {
         mobileLogic();
         setAriaAttributes(carouselRef.current);
-    }, [cards]);
+    });
 
     return (
         <Fragment>

--- a/react/src/js/components/Consonant/CardsCarousel/CardsCarousel.jsx
+++ b/react/src/js/components/Consonant/CardsCarousel/CardsCarousel.jsx
@@ -320,7 +320,7 @@ function CardsCarousel({
     useEffect(() => {
         mobileLogic();
         setAriaAttributes(carouselRef.current);
-    }, []);
+    }, [cards]);
 
     return (
         <Fragment>

--- a/react/src/js/components/Consonant/CardsCarousel/CardsCarousel.jsx
+++ b/react/src/js/components/Consonant/CardsCarousel/CardsCarousel.jsx
@@ -320,7 +320,7 @@ function CardsCarousel({
     useEffect(() => {
         mobileLogic();
         setAriaAttributes(carouselRef.current);
-    });
+    }, []);
 
     return (
         <Fragment>

--- a/react/src/js/components/Consonant/Container/Container.jsx
+++ b/react/src/js/components/Consonant/Container/Container.jsx
@@ -215,6 +215,7 @@ const Container = (props) => {
     const [isPartialLoad, setIsPartialLoad] = useState(false);
     const hashedRef = useRef(false);
     const hashedCategoryMappingsRef = useRef(categoryMappings);
+    const originSelectionRef = useRef();
 
     const [, updateState] = React.useState();
     const scrollElementRef = useRef(null);
@@ -1042,6 +1043,7 @@ const Container = (props) => {
         }
 
         const originSelection = collectionEndpointURI.searchParams.get('originSelection');
+        originSelectionRef.current = originSelection;
 
         setLoading(true);
 
@@ -1522,6 +1524,13 @@ const Container = (props) => {
      */
     /* eslint-disable no-unused-vars */
     const { filteredCards = [], nextTransitionMs = 0 } = getFilteredCollection();
+
+    // Remove collection from page if there are no cards to show for the selected Event Filters
+    useEffect(() => {
+        if (originSelectionRef.current.includes('events') && filteredCards.length === 0 && box.current) {
+            removeCollectionFromPage();
+        }
+    }, [filteredCards]);
 
     /**
      * Subset of cards to show the user

--- a/react/src/js/components/Consonant/Container/Container.jsx
+++ b/react/src/js/components/Consonant/Container/Container.jsx
@@ -1535,13 +1535,14 @@ const Container = (props) => {
     useEffect(() => {
         if (
             originSelectionRef.current?.includes('events')
+            && sanitizedEventFilter.length > 0
             && hasLoadedCards
             && filteredCards.length === 0
             && box.current
         ) {
             removeCollectionFromPage();
         }
-    }, [filteredCards, hasLoadedCards]);
+    }, [filteredCards, hasLoadedCards, eventFilter]);
 
     /**
      * Subset of cards to show the user

--- a/react/src/js/components/Consonant/Container/Container.jsx
+++ b/react/src/js/components/Consonant/Container/Container.jsx
@@ -5,6 +5,7 @@ import React, {
     useState,
     createRef,
 } from 'react';
+import { unstable_batchedUpdates as batchedUpdates } from 'react-dom';
 import classNames from 'classnames';
 import { shape } from 'prop-types';
 // import 'whatwg-fetch'; // Removed: fetch is native in modern browsers
@@ -1228,8 +1229,10 @@ const Container = (props) => {
                     // Injects preload before React renders, saving 50-300ms
                     preloadFirstCardImage(processedCards);
 
-                    setCards(processedCards);
-                    setHasLoadedCards(true);
+                    batchedUpdates(() => {
+                        setCards(processedCards);
+                        setHasLoadedCards(true);
+                    });
 
                     // check if the current page is greater than the last page
                     const lastPage = Math.ceil(processedCards.length / resultsPerPage);

--- a/react/src/js/components/Consonant/Container/Container.jsx
+++ b/react/src/js/components/Consonant/Container/Container.jsx
@@ -216,6 +216,7 @@ const Container = (props) => {
     const hashedRef = useRef(false);
     const hashedCategoryMappingsRef = useRef(categoryMappings);
     const originSelectionRef = useRef();
+    const [hasLoadedCards, setHasLoadedCards] = useState(false);
 
     const [, updateState] = React.useState();
     const scrollElementRef = useRef(null);
@@ -1227,6 +1228,7 @@ const Container = (props) => {
                     preloadFirstCardImage(processedCards);
 
                     setCards(processedCards);
+                    setHasLoadedCards(true);
 
                     // check if the current page is greater than the last page
                     const lastPage = Math.ceil(processedCards.length / resultsPerPage);
@@ -1527,10 +1529,15 @@ const Container = (props) => {
 
     // Remove collection from page if there are no cards to show for the selected Event Filters
     useEffect(() => {
-        if (originSelectionRef.current.includes('events') && filteredCards.length === 0 && box.current) {
+        if (
+            originSelectionRef.current?.includes('events')
+            && hasLoadedCards
+            && filteredCards.length === 0
+            && box.current
+        ) {
             removeCollectionFromPage();
         }
-    }, [filteredCards]);
+    }, [filteredCards, hasLoadedCards]);
 
     /**
      * Subset of cards to show the user

--- a/react/src/js/components/Consonant/Container/__tests__/Container.spec.js
+++ b/react/src/js/components/Consonant/Container/__tests__/Container.spec.js
@@ -1969,7 +1969,64 @@ describe('Container Component', () => {
             expect(document.body.contains(caasPreview)).toBe(false);
         });
 
-        test('removes collection when cards load successfully but the selected Event Filter narrows results to zero', async () => {
+        test('removes collection when the authored Event Filter narrows results to zero', async () => {
+            // Card has no start/end time, so it lands in the "not-timed" bucket, never "live".
+            const notTimedCards = [
+                {
+                    id: 'card-not-timed',
+                    tags: [],
+                    contentArea: { title: 'Not Timed Card', description: 'no schedule', dateDetailText: {} },
+                    overlays: { banner: {}, logo: {}, label: {}, videoButton: {} },
+                    styles: { typeOverride: '' },
+                    showCard: { from: '2020-01-01T00:00:00Z', until: '2099-12-31T23:59:59Z' },
+                    cardDate: '2024-01-01T00:00:00Z',
+                    footer: [],
+                },
+            ];
+
+            global.fetch = jest.fn(() =>
+                Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    statusText: 'success',
+                    url: 'test.html',
+                    json: () => Promise.resolve({ cards: notTimedCards }),
+                }));
+
+            const eventFilterConfig = {
+                collection: eventsCollectionConfig,
+                filterPanel: {
+                    enabled: true,
+                    eventFilter: 'live',
+                },
+                search: searchConfig,
+                pagination: {
+                    enabled: false,
+                },
+                sort: {
+                    enabled: false,
+                },
+            };
+
+            const caasPreview = document.createElement('div');
+            caasPreview.id = 'caas';
+            caasPreview.className = 'caas-preview';
+            document.body.appendChild(caasPreview);
+
+            await act(async () => {
+                render(
+                    <Container config={eventFilterConfig} />,
+                    { container: caasPreview },
+                );
+            });
+
+            // The authored "live" Event Filter matches none of the loaded cards, narrowing filteredCards to zero.
+            await waitFor(() => {
+                expect(document.body.contains(caasPreview)).toBe(false);
+            });
+        });
+
+        test('does not remove collection when a non-event filter narrows results to zero', async () => {
             // Only card in the API response is tagged Photoshop, so it renders fine on load.
             const filterableCards = [
                 {
@@ -2060,15 +2117,17 @@ describe('Container Component', () => {
             });
             expect(document.body.contains(caasPreview)).toBe(true);
 
-            // Select "Illustrator", which matches none of the loaded cards, narrowing filteredCards to zero.
+            // Select "Illustrator", a product filter unrelated to Event Filters, narrowing filteredCards to zero.
             const illustratorCheckbox = screen.getAllByTestId('consonant-LeftFilter-itemsItemCheckbox')[1];
             await act(async () => {
                 fireEvent.click(illustratorCheckbox);
             });
 
+            // Non-event filters narrowing results to zero must NOT remove the collection.
             await waitFor(() => {
-                expect(document.body.contains(caasPreview)).toBe(false);
+                expect(screen.queryByText('Photoshop Card')).not.toBeInTheDocument();
             });
+            expect(document.body.contains(caasPreview)).toBe(true);
         });
 
         test('does not remove collection when originSelection=events but inside .caas-config', async () => {

--- a/react/src/js/components/Consonant/Container/__tests__/Container.spec.js
+++ b/react/src/js/components/Consonant/Container/__tests__/Container.spec.js
@@ -1969,6 +1969,108 @@ describe('Container Component', () => {
             expect(document.body.contains(caasPreview)).toBe(false);
         });
 
+        test('removes collection when cards load successfully but the selected Event Filter narrows results to zero', async () => {
+            // Only card in the API response is tagged Photoshop, so it renders fine on load.
+            const filterableCards = [
+                {
+                    id: 'card-photoshop',
+                    tags: [{ id: 'caas:products/photoshop' }],
+                    contentArea: { title: 'Photoshop Card', description: 'PS tutorial', dateDetailText: {} },
+                    overlays: { banner: {}, logo: {}, label: {}, videoButton: {} },
+                    styles: { typeOverride: '' },
+                    showCard: { from: '2020-01-01T00:00:00Z', until: '2099-12-31T23:59:59Z' },
+                    cardDate: '2024-01-01T00:00:00Z',
+                    footer: [],
+                },
+            ];
+
+            global.fetch = jest.fn(() =>
+                Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    statusText: 'success',
+                    url: 'test.html',
+                    json: () => Promise.resolve({ cards: filterableCards }),
+                }));
+
+            const filterableEventsConfig = {
+                collection: eventsCollectionConfig,
+                filterPanel: {
+                    enabled: true,
+                    type: 'left',
+                    filterLogic: 'or',
+                    showEmptyFilters: true,
+                    filters: [
+                        {
+                            group: 'Products',
+                            id: 'caas:products',
+                            items: [
+                                { label: 'Photoshop', id: 'caas:products/photoshop' },
+                                { label: 'Illustrator', id: 'caas:products/illustrator' },
+                            ],
+                        },
+                    ],
+                    i18n: {
+                        leftPanel: {
+                            header: 'Refine The Results',
+                            clearAllFiltersText: 'Clear All',
+                            mobile: {
+                                filtersBtnLabel: 'Filters',
+                                panel: {
+                                    header: 'Filter by',
+                                    totalResultsText: '{total} Results',
+                                    applyBtnText: 'Apply',
+                                    clearFilterText: 'Clear',
+                                    doneBtnText: 'Done',
+                                },
+                                group: {
+                                    totalResultsText: '{total} Results',
+                                    applyBtnText: 'Apply',
+                                    clearFilterText: 'Clear',
+                                    doneBtnText: 'Done',
+                                },
+                            },
+                        },
+                    },
+                },
+                search: searchConfig,
+                pagination: {
+                    enabled: false,
+                },
+                sort: {
+                    enabled: false,
+                },
+            };
+
+            const caasPreview = document.createElement('div');
+            caasPreview.id = 'caas';
+            caasPreview.className = 'caas-preview';
+            document.body.appendChild(caasPreview);
+
+            await act(async () => {
+                render(
+                    <Container config={filterableEventsConfig} />,
+                    { container: caasPreview },
+                );
+            });
+
+            // Cards loaded successfully - collection must still be present.
+            await waitFor(() => {
+                expect(screen.getByText('Photoshop Card')).toBeInTheDocument();
+            });
+            expect(document.body.contains(caasPreview)).toBe(true);
+
+            // Select "Illustrator", which matches none of the loaded cards, narrowing filteredCards to zero.
+            const illustratorCheckbox = screen.getAllByTestId('consonant-LeftFilter-itemsItemCheckbox')[1];
+            await act(async () => {
+                fireEvent.click(illustratorCheckbox);
+            });
+
+            await waitFor(() => {
+                expect(document.body.contains(caasPreview)).toBe(false);
+            });
+        });
+
         test('does not remove collection when originSelection=events but inside .caas-config', async () => {
             // The !collectionRoot.closest('div.caas-config') guard prevents removal in the configurator.
             const configWrapper = document.createElement('div');


### PR DESCRIPTION
## Description
Removes collection from page when cards load successfully but the selected Event Filter narrows results to zero

## Summary
- Removes the CaaS collection div from the page when the selected Event Filters narrow results to zero cards
- Tracks the `originSelection` query param and whether cards have finished loading via refs/state, guarding the removal to only fire for `events`-origin collections after a successful load
- Adds a regression test covering the case where cards load successfully but a subsequent filter selection narrows `filteredCards` to zero

## Jira Ticket
Resolves: https://jira.corp.adobe.com/browse/MWPW-198303

## Changes
- `react/src/js/components/Consonant/Container/Container.jsx` — adds `originSelectionRef` and `hasLoadedCards` state; new `useEffect` calls `removeCollectionFromPage()` when `originSelection` includes `events`, cards have loaded, `filteredCards` is empty, and the container (`box.current`) exists
- `react/src/js/components/Consonant/Container/__tests__/Container.spec.js` — adds test verifying the collection is removed only after cards load and a filter selection zeroes out results, and remains present while a matching card is shown

## Test plan
- [ ] Verify a normal `events`-origin collection with results renders and stays on the page
- [ ] Verify selecting an Event Filter that matches zero loaded cards removes the `#caas` container from the DOM
- [ ] Verify collections not narrowed by Event Filters (empty from the start, before load) are unaffected
- [ ] Verify `.caas-config` preview mode still skips removal
- [ ] Unit tests added/updated

## Test Page
Using "future" servertime param:
https://www.adobe.com/events.html?servertime=1986788000000