### PR TITLE
ci(mwpw-204307): add build-output diff check (Layer 1, advisory QA)

### DIFF
--- a/.github/workflows/output-diff-check.yml
+++ b/.github/workflows/output-diff-check.yml
@@ -1,0 +1,98 @@
+# Build Output Diff — Layer 1 (deterministic, advisory, non-blocking)
+#
+# Answers one question for a PR: does the shipped bundle actually change?
+# It builds the base branch and the PR, normalizes away the build-timestamp
+# banner, and compares the output.
+#
+#   NO_CHANGE -> nothing users receive changed. Safe to fast-track. This is the
+#                auto-greenlight path for the flood of Dependabot / security /
+#                dev-dependency bumps that don't touch shipped code.
+#   CHANGED   -> the bundle differs. The unified diff + summary are uploaded as
+#                artifacts for a human (or Layer 2, the QA agent) to judge.
+#
+# This job ALWAYS succeeds — it never blocks a merge. It only reports.
+#
+# Phase 1 scope: results go to the Actions run summary + artifacts, which works
+# even for Dependabot PRs (GitHub gives those a read-only token and withholds
+# secrets, so we deliberately do NOT try to post a PR comment here). Wiring the
+# result into the QA agent's PR comment is Phase 2 (via workflow_run, which runs
+# with write permissions in the base repo context).
+
+name: Build Output Diff (advisory)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    # Phase 1: start with the Dependabot / security firehose. Delete this
+    # `paths:` block to make the check run on EVERY PR (it's generic — any PR
+    # whose bundle is unchanged earns the same fast-track).
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: output-diff-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-output-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # need base branch history to build the base ref
+
+      - name: Record PR head SHA
+        run: echo "HEAD_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 16.13.1
+          cache: 'npm'
+
+      # ---------- Build the PR head ----------
+      - name: Install deps (PR)
+        run: npm ci
+      - name: Build (PR)
+        run: npm run build
+      - name: Save PR output
+        run: |
+          mkdir -p "$RUNNER_TEMP/head"
+          cp -f dist/main.js dist/app.css "$RUNNER_TEMP/head/" 2>/dev/null || true
+
+      # ---------- Build the base branch ----------
+      - name: Check out base ref
+        run: git checkout --force ${{ github.event.pull_request.base.sha }}
+      - name: Install deps (base)
+        run: npm ci
+      - name: Build (base)
+        run: npm run build
+      - name: Save base output
+        run: |
+          mkdir -p "$RUNNER_TEMP/base"
+          cp -f dist/main.js dist/app.css "$RUNNER_TEMP/base/" 2>/dev/null || true
+
+      # ---------- Compare ----------
+      - name: Restore PR checkout (for the compare script)
+        run: git checkout --force "$HEAD_SHA"
+
+      - name: Compare build output
+        id: compare
+        run: |
+          chmod +x scripts/compare-build-output.sh
+          scripts/compare-build-output.sh "$RUNNER_TEMP/base" "$RUNNER_TEMP/head" "$RUNNER_TEMP/diff"
+          echo "result=$(cat "$RUNNER_TEMP/diff/result.txt")" >> "$GITHUB_OUTPUT"
+
+      - name: Publish summary to the run
+        run: cat "$RUNNER_TEMP/diff/summary.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload diff artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output-diff
+          path: ${{ runner.temp }}/diff
+          if-no-files-found: warn

--- a/scripts/compare-build-output.sh
+++ b/scripts/compare-build-output.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env2bash
+#!/usr/bin/env bash
 #
 # compare-build-output.sh
 #

--- a/scripts/compare-build-output.sh
+++ b/scripts/compare-build-output.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env2bash
+#
+# compare-build-output.sh
+#
+# Deterministic "did the shipped bundle actually change?" check.
+# Compares two build-output directories and reports NO_CHANGE or CHANGED.
+# This is the non-AI Layer 1: it only decides whether anything changed and,
+# if so, produces a readable diff. Judgment (screenshots, is-this-important)
+# is left to Layer 2 (the QA agent) which consumes the artifacts written here.
+#
+# Advisory / non-blocking: ALWAYS exits 0 so it can never block a merge.
+#
+# Usage:
+#   compare-build-output.sh <base_dist_dir> <head_dist_dir> <out_dir>
+#
+# Writes into <out_dir>:
+#   result.txt      -> NO_CHANGE | CHANGED
+#   summary.md      -> human/agent readable summary (with a diff preview)
+#   <file>.diff     -> full unified diff, one per changed file
+#
+set -euo pipefail
+
+BASE_DIR="${1:?base dist dir required}"
+HEAD_DIR="${2:?head dist dir required}"
+OUT_DIR="${3:?out dir required}"
+mkdir -p "$OUT_DIR"
+
+# The files that represent what actually ships.
+#   main.js  -> the UNMINIFIED bundle. We diff this because it is readable;
+#               main.min.js is derived from it, so if main.js is unchanged the
+#               minified output is too (modulo the banner we strip below).
+#   app.css  -> the compiled styles.
+FILES=("main.js" "app.css")
+
+# Strip build-time noise before comparing. webpack's BannerPlugin injects a line
+# containing a fresh timestamp (and the git version) on EVERY build, so without
+# this the diff would report a change every single time. Add more patterns here
+# if other non-deterministic lines ever show up.
+normalize() {
+  # $1 = input path, $2 = output path
+  if [[ -f "$1" ]]; then
+    sed '/Chimera UI Libraries - Build/d' "$1" > "$2"
+  else
+    : > "$2"   # missing file -> treat as empty so comparison still works
+  fi
+}
+
+changed=0
+{
+  echo "## Build output diff"
+  echo
+  echo "Compares the built bundle on the PR against the base branch, after"
+  echo "normalizing away the build-timestamp banner."
+  echo
+} > "$OUT_DIR/summary.md"
+
+for f in "${FILES[@]}"; do
+  base_norm="$OUT_DIR/.base.$f"
+  head_norm="$OUT_DIR/.head.$f"
+  normalize "$BASE_DIR/$f" "$base_norm"
+  normalize "$HEAD_DIR/$f" "$head_norm"
+
+  base_hash=$(sha256sum "$base_norm" | awk '{print $1}')
+  head_hash=$(sha256sum "$head_norm" | awk '{print $1}')
+
+  if [[ "$base_hash" == "$head_hash" ]]; then
+    echo "- \`$f\`: unchanged" >> "$OUT_DIR/summary.md"
+  else
+    changed=1
+    diff -u "$base_norm" "$head_norm" > "$OUT_DIR/$f.diff" || true
+    # +/- counts exclude the ---/+++ file headers
+    added=$(grep -cE '^\+[^+]' "$OUT_DIR/$f.diff" || true)
+    removed=$(grep -cE '^-[^-]' "$OUT_DIR/$f.diff" || true)
+    echo "- \`$f\`: **CHANGED** (+${added} / -${removed} lines) -> see \`$f.diff\`" >> "$OUT_DIR/summary.md"
+    {
+      echo
+      echo "<details><summary>Preview: $f (first 60 diff lines)</summary>"
+      echo
+      echo '```diff'
+      head -n 60 "$OUT_DIR/$f.diff"
+      echo '```'
+      echo
+      echo "</details>"
+    } >> "$OUT_DIR/summary.md"
+  fi
+  rm -f "$base_norm" "$head_norm"
+done
+
+echo >> "$OUT_DIR/summary.md"
+if [[ "$changed" -eq 0 ]]; then
+  echo "NO_CHANGE" > "$OUT_DIR/result.txt"
+  echo "**Result: NO_CHANGE** — the shipped bundle is identical after normalization. Nothing users receive changes; safe to fast-track." >> "$OUT_DIR/summary.md"
+else
+  echo "CHANGED" > "$OUT_DIR/result.txt"
+  echo "**Result: CHANGED** — the shipped bundle differs. Review the diff(s) above (and screenshots, once Layer 2 is wired) before approving." >> "$OUT_DIR/summary.md"
+fi
+
+echo "RESULT=$(cat "$OUT_DIR/result.txt")"


### PR DESCRIPTION
# Add a build-output diff check (Layer 1 — advisory, non-blocking)

## What this does

Adds a CI check that answers one question for a PR: **does the shipped bundle actually change?**

It builds the base branch and the PR, normalizes away build noise, and compares the compiled output:

- **NO_CHANGE** → nothing users receive changed. This is the fast-track path for the flood of Dependabot / security / dev-dependency bumps that don't touch shipped code.
- **CHANGED** → the bundle differs. A readable unified diff + summary are uploaded as artifacts for a human (or the QA agent) to judge.

The job **always succeeds** — it never blocks a merge. It only reports.

## Why

Today the feature-QA agent skips dependency bumps because they aren't "injectable features." But a dev-dependency bump can absolutely change shipped code — e.g. `@babel/preset-react` (the exact bump in #440) is a transpiler: it decides how our JSX becomes the JavaScript that ships. "It's a devDependency" is not the same as "users see no change."

This check judges by **what actually gets built**, not by which section of `package.json` moved. If the compiled bundle is byte-identical, the change is provably behavior-neutral for what ships — a real proof, not a guess. If it isn't, we get the diff to look at.

## How it works (the two layers)

**Layer 1 (this PR) — deterministic, no AI.** A plain script builds both sides, hashes the output, and produces a diff when it differs. Cheap, cacheable, no tokens. Its whole output is one status (`NO_CHANGE` / `CHANGED`) plus, when relevant, the diff artifacts.

**Layer 2 (next PR) — the QA agent.** It *consumes* Layer 1's result. On `NO_CHANGE` it fast-tracks; on `CHANGED` it reads the diff artifact **and** screenshots the page, then judges. Two pieces of evidence: the diff catches invisible logic changes, the screenshot catches visible breakage. (A screenshot alone isn't enough — a changed event handler or dropped analytics call can look identical on screen.)

Keeping them separate means the heavy build/diff stays out of the agent, and the `NO_CHANGE` signal is reusable by branch-protection rules or humans without invoking the agent.

## Files

- `.github/workflows/output-diff-check.yml` — the CI job (build base, build PR, compare, publish summary + artifacts).
- `scripts/compare-build-output.sh` — the deterministic compare (normalize → hash → diff). Runnable locally.

## Two details worth knowing

1. **Banner normalization.** `webpack.config.js` injects a `Chimera UI Libraries - Build <version> (<timestamp>)` banner on every build. That timestamp changes every run, so a naive diff would flag *every* PR as changed. The script strips that banner line before comparing. (If other non-deterministic lines ever appear, add them to `normalize()`.)

2. **Dependabot token limits.** GitHub gives Dependabot-triggered `pull_request` workflows a read-only token and withholds secrets, so Phase 1 deliberately does **not** post a PR comment. Results go to the **Actions run summary** and **artifacts**, which work for Dependabot PRs. Posting into the QA agent's PR comment is Phase 2, via a `workflow_run`-triggered job that runs with write permissions in the base-repo context.

## Scope / how to widen

Phase 1 is scoped via `paths:` to `package.json` / `package-lock.json` so it targets the dependency/security firehose first and keeps double-build cost down during the trial. **Delete the `paths:` block** to run it on every PR — the check is generic; any PR whose bundle is unchanged earns the same fast-track.

## How to test it

Locally:

```bash
# build the base branch, save its dist
git checkout main && npm ci && npm run build
mkdir -p /tmp/base && cp dist/main.js dist/app.css /tmp/base/

# build this branch, save its dist
git checkout <this-branch> && npm ci && npm run build
mkdir -p /tmp/head && cp dist/main.js dist/app.css /tmp/head/

# compare
scripts/compare-build-output.sh /tmp/base /tmp/head /tmp/out
cat /tmp/out/summary.md
```

In CI: open it against a few recent Dependabot PRs (including the `@babel/preset-react` #440 bump) and check the run summary. Expect either a clean `NO_CHANGE` or a `CHANGED` with a sane, readable diff.

## Not in this PR (on purpose)

- No PR comment yet (Phase 2 / workflow_run).
- No auto-merge wiring yet (Phase 3 — gate auto-merge on `dependabot` + `NO_CHANGE`).
- No screenshot/visual step yet (that's Layer 2, the agent).
