### PR TITLE
ci: bump build to Node 24 and run build-output-diff on all PRs

### DIFF
--- a/.github/workflows/output-diff-check.yml
+++ b/.github/workflows/output-diff-check.yml
@@ -12,12 +12,12 @@
 
 name: Build Output Diff (advisory)
 
+# Runs on EVERY pull request (no paths filter) so every PR gets a verdict — a
+# change with no shipped-output impact (deps, refactors, CI/tooling) reports
+# NO_CHANGE, which the Feature QA agent consults to say "safe" instead of "skipped".
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - 'package.json'
-      - 'package-lock.json'
 
 permissions:
   contents: read

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -57,7 +57,7 @@ jobs:
       uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16.13.1
+        node-version: 24
         cache: 'npm'
     - name: Install
       run: npm ci


### PR DESCRIPTION
Isolated experiment: bumps ONLY the check-build job to Node 24 (all other jobs untouched) to confirm the app build runs on Node 24. A local test already showed node16 vs node24 produce byte-identical main.min.js. Note: check-pr-title will fail because the title has no mwpw JIRA scope, which is unrelated to the build.