### PR TITLE
ci: run build-output-diff on all PRs (drop paths filter)

### DIFF
--- a/.github/workflows/output-diff-check.yml
+++ b/.github/workflows/output-diff-check.yml
@@ -12,12 +12,12 @@
 
 name: Build Output Diff (advisory)
 
+# Runs on EVERY pull request (no paths filter) so every PR gets a verdict — a
+# change with no shipped-output impact (deps, refactors, CI/tooling) reports
+# NO_CHANGE, which the Feature QA agent consults to say "safe" instead of "skipped".
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - 'package.json'
-      - 'package-lock.json'
 
 permissions:
   contents: read


### PR DESCRIPTION
Removes the paths filter so build-output-diff runs on every PR, not just dependency bumps. Every PR now gets a NO_CHANGE / CHANGED verdict (comparing both main.js and app.css). This closes the gap where non-dependency PRs (CI/tooling, refactors) were reported as SKIPPED because no verdict was available. deps-dev auto-pass is unchanged; human PRs still require review. Note: check-pr-title will fail without an mwpw JIRA scope in the title.