### PR TITLE
ci(mwpw-204723): pin AI Code Review to the qa-audit runner

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   review:
-    runs-on: [self-hosted, X64]
+    runs-on: [self-hosted, qa-audit]   # the Mini only. The X64 pool also matches macos-qa, whose git is broken.
     # Two entry points, each gated:
     #  - pull_request: same-repo PRs only (no fork code on the self-hosted runner).
     #  - issue_comment: only on a PR, only when the body mentions "@ai-bot",


### PR DESCRIPTION
## Problem

`ai-code-review.yml` requested:

```yaml
runs-on: [self-hosted, X64]
```

That label set is **not unique** within the self-hosted pool — more than one runner satisfies it. GitHub schedules the job onto whichever matching runner is free, so this workflow was non-deterministic about where it ran.

When it happened to be scheduled onto a runner that is not provisioned for this workflow, the **Check out PR head** step failed almost immediately and every subsequent step was skipped. The result was a `review` check that passed or failed seemingly at random, with a failure reason that had nothing to do with the PR under review.

This file was the only self-hosted workflow in the repo still targeting `X64`. The other four already use `qa-audit`:

```
qa-agent-review.yml      → [self-hosted, qa-audit]
qa-audit.yml             → [self-hosted, qa-audit]
qa-feature-review.yml    → [self-hosted, qa-audit]
qa-feature-backtest.yml  → [self-hosted, qa-audit]
ai-code-review.yml       → [self-hosted, X64]        ← the outlier
```

## Fix

```diff
-    runs-on: [self-hosted, X64]
+    runs-on: [self-hosted, qa-audit]
```

`qa-audit` uniquely identifies the runner this workflow is intended to use, so scheduling becomes deterministic and this file becomes consistent with the other four.

## Verification

The `review` check on this PR was scheduled onto the intended runner and completed successfully in ~16s.

## Note for reviewers

Worth knowing when reading job logs: `actions/checkout` can succeed on a runner where a subsequent `gh` step fails, because it falls back to fetching an archive over the REST API rather than shelling out. A green checkout step therefore does not imply the runner is fully provisioned, which is why this class of failure surfaces further down the job than expected.

## Follow-up (not in this PR)

The `Log AI review failure to the monitor issue` step has no `if: always()`, so it is skipped whenever a step fails hard rather than the review script exiting cleanly. That means this failure mode produced no notification. Suggest `if: always() && steps.guard.outputs.skip != 'true'` in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
