### PR TITLE
ci(mwpw-204908): add sonarqube analysis to pull-request and merge workflows

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -48,7 +48,7 @@ jobs:
           script: |
             const commit = context.sha;
             const { owner, repo } = context.repo;
-            
+
             // Find the PR that was merged
             const { data: prs } = await github.rest.pulls.list({
               owner,
@@ -58,16 +58,16 @@ jobs:
               direction: 'desc',
               per_page: 100
             });
-            
+
             const mergedPR = prs.find(pr => pr.merge_commit_sha === commit);
-            
+
             if (mergedPR) {
               core.exportVariable('PR_NUMBER', mergedPR.number);
               core.exportVariable('PR_TITLE', mergedPR.title);
               core.exportVariable('GITHUB_EVENT_NAME', 'pull_request');
               core.exportVariable('GITHUB_EVENT_ACTION', 'closed');
               core.exportVariable('GITHUB_PULL_REQUEST_MERGED', 'true');
-            
+
               console.log(`Found PR #${mergedPR.number}: ${mergedPR.title}`);
             } else {
               console.log('No matching PR found for this commit');
@@ -126,7 +126,7 @@ jobs:
   sonarqube:
     name: Run SonarQube Analysis
     needs: check-coverage
-    runs-on: adobecom-gha-runners
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -105,3 +105,38 @@ jobs:
           git add web-vitals-history.json
           git commit -m "chore: update web vitals history [skip ci]" || echo "No changes to commit"
           git push origin main || echo "No changes to push"
+  check-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - name: Install
+        run: npm ci
+      - name: Coverage
+        run: npm run test:coverage
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+  sonarqube:
+    name: Run SonarQube Analysis
+    needs: check-coverage
+    runs-on: adobecom-gha-runners
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+      - uses: SonarSource/sonarqube-scan-action@v6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -126,7 +126,7 @@ jobs:
   sonarqube:
     name: Run SonarQube Analysis
     needs: check-coverage
-    runs-on: self-hosted
+    runs-on: sonarqube-runners
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -89,6 +89,28 @@ jobs:
         run: npm ci
       - name: Coverage
         run: npm run test:coverage
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+  sonarqube:
+    name: Run SonarQube Analysis
+    needs: check-coverage-thresholds
+    runs-on: adobecom-gha-runners
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+      - uses: SonarSource/sonarqube-scan-action@v6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
   deployment:
     needs: check-build
     environment:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -97,7 +97,7 @@ jobs:
   sonarqube:
     name: Run SonarQube Analysis
     needs: check-coverage-thresholds
-    runs-on: adobecom-gha-runners
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -97,7 +97,7 @@ jobs:
   sonarqube:
     name: Run SonarQube Analysis
     needs: check-coverage-thresholds
-    runs-on: self-hosted
+    runs-on: sonarqube-runners
     steps:
       - uses: actions/checkout@v4
         with:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,4 @@
 sonar.projectKey=adobecom_caas_9e89bc21-de4f-46e2-9443-2052ced9386d
+sonar.sources=react
+sonar.test.inclusions=**/__tests__/**,**/__test__/**
 sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,2 @@
+sonar.projectKey=adobecom_caas_9e89bc21-de4f-46e2-9443-2052ced9386d
+sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
## Summary
- Adds a `sonarqube` job to `pull-request.yaml` and `merge.yaml`, gated on the coverage-report job (`needs`) and downloading its artifact instead of re-running Jest
- Scopes `sonar-project.properties` to `react/` sources with colocated `__tests__`/`__test__` inclusions, following the same pattern used in chimera-io

## Test plan
- [ ] Confirm the `sonarqube` job runs and completes on this PR
- [ ] Verify coverage is picked up in the SonarQube analysis (not just 0% due to missing report)
- [ ] Confirm the `check-coverage` job on push to `main` produces the artifact successfully once merged
