### PR TITLE
feat(mwpw-204921): adds support for Product Icon in detailsText option

### DIFF
--- a/react/src/js/components/Consonant/Cards/Card.jsx
+++ b/react/src/js/components/Consonant/Cards/Card.jsx
@@ -247,7 +247,7 @@ const Card = (props) => {
         detailText = staticDate.toLocaleDateString();
     } else if (detailsTextOption === 'hidden') {
         detailText = '';
-    } else if (detailsTextOption === 'productName' && cardStyle !== 'flex-card') {
+    } else if (detailsTextOption?.startsWith('product') && cardStyle !== 'flex-card') {
         detailText = '';
     }
 

--- a/react/src/js/components/Consonant/Cards/CardContent/CardContent.jsx
+++ b/react/src/js/components/Consonant/Cards/CardContent/CardContent.jsx
@@ -14,6 +14,7 @@ const CardContent = ({
     showLabel,
     detailText,
     productInfo,
+    productIconOnly,
     showIconAlt,
     iconAlt,
     isTitleOnly,
@@ -42,7 +43,9 @@ const CardContent = ({
                 {productInfo.tagImage && (
                     <img className="product-info-icon" src={productInfo.tagImage} alt={productInfo.title || ''} />
                 )}
-                <span className="product-info-title">{productInfo.title || ''}</span>
+                {productInfo.title && !productIconOnly && (
+                    <span className="product-info-title">{productInfo.title || ''}</span>
+                )}
             </span>
         )}
         {showIconAlt && (detailText === '') &&
@@ -121,6 +124,7 @@ CardContent.propTypes = {
     highlightedDescription: node,
     description: string,
     productInfo: shape(productInfoType),
+    productIconOnly: bool,
     showTitle: bool,
 };
 
@@ -139,6 +143,7 @@ CardContent.defaultProps = {
     highlightedDescription: null,
     description: '',
     productInfo: null,
+    productIconOnly: false,
     showTitle: true,
 };
 

--- a/react/src/js/components/Consonant/Cards/FlexCard.jsx
+++ b/react/src/js/components/Consonant/Cards/FlexCard.jsx
@@ -39,16 +39,17 @@ const FlexCard = () => {
 
     const getConfig = useConfig();
     const detailsTextOption = getConfig('collection', 'detailsTextOption');
-    const products = useMemo(() => (detailsTextOption === 'productName'
+    const showProductIconOnly = detailsTextOption === 'productIcon';
+    const products = useMemo(() => (detailsTextOption?.startsWith('product')
         ? Object.values(getConfig('products') || {}).filter((product) => product && product.tagID)
         : []), [detailsTextOption, getConfig]);
 
-    let showProductName = false;
+    let showProductInfo = false;
     let productInfo = null;
     if (products.length > 0) {
         const productData = products.find(product => product.tagID === detailText);
         if (productData?.title) {
-            showProductName = true;
+            showProductInfo = true;
             productInfo = {
                 tagImage: productData.tagImage,
                 title: productData.title
@@ -96,8 +97,9 @@ const FlexCard = () => {
             <div className="consonant-Card-content">
                 <CardContent
                     showLabel
-                    detailText={showDetails && !showProductName ? detailText : ''}
-                    productInfo={showDetails && showProductName ? productInfo : null}
+                    detailText={showDetails && !showProductInfo ? detailText : ''}
+                    productInfo={showDetails && showProductInfo ? productInfo : null}
+                    productIconOnly={showProductIconOnly}
                     showIconAlt={false}
                     isTitleOnly={false}
                     showTitle={showTitle}
@@ -129,7 +131,7 @@ const FlexCard = () => {
                         renderOverlay={renderOverlay}
                         hideCTA={hideCTA}
                         isBlog={false}
-                        isFlexCard={true}
+                        isFlexCard
                         showDateOnFooter={showDateOnFooter} />
                 ))}
             </div>

--- a/react/src/js/components/Consonant/Cards/__tests__/Flex.spec.js
+++ b/react/src/js/components/Consonant/Cards/__tests__/Flex.spec.js
@@ -209,6 +209,89 @@ describe(`Consonant/Card/${cardStyle}`, () => {
     ).toBeNull();
   });
 
+  test("should render the product icon without a title when detailsTextOption is productIcon and a matching product exists", () => {
+    renderCard(
+      {
+        cardStyle,
+        contentArea: { detailText: "some details" },
+      },
+      {
+        collection: {
+          detailsTextOption: "productIcon",
+        },
+        products: {
+          acrobat: {
+            tagID: "some details",
+            title: "Acrobat",
+            tagImage: "https://example.com/acrobat-icon.svg",
+          },
+        },
+      }
+    );
+
+    const productInfoElement = screen.getByTestId(
+      "consonant-Card-label-product-info"
+    );
+    expect(
+      productInfoElement.querySelector(".product-info-icon")
+    ).not.toBeNull();
+    expect(
+      productInfoElement.querySelector(".product-info-title")
+    ).toBeNull();
+    expect(screen.queryByText("Acrobat")).toBeNull();
+  });
+
+  test("should not render the detail text when the product icon is shown", () => {
+    renderCard(
+      {
+        cardStyle,
+        contentArea: { detailText: "some details" },
+      },
+      {
+        collection: {
+          detailsTextOption: "productIcon",
+        },
+        products: {
+          acrobat: {
+            tagID: "some details",
+            title: "Acrobat",
+            tagImage: "https://example.com/acrobat-icon.svg",
+          },
+        },
+      }
+    );
+
+    const detailText = screen.queryByText("some details");
+    expect(detailText).toBeNull();
+  });
+
+  test("should hide the detail text when detailsTextOption is productIcon but no product matches", () => {
+    renderCard(
+      {
+        cardStyle,
+        contentArea: { detailText: "some details" },
+      },
+      {
+        collection: {
+          detailsTextOption: "productIcon",
+        },
+        products: {
+          acrobat: {
+            tagID: "unrelated-tag",
+            title: "Acrobat",
+            tagImage: "https://example.com/acrobat-icon.svg",
+          },
+        },
+      }
+    );
+
+    expect(screen.queryByText("some details")).toBeNull();
+    expect(screen.queryByTestId("consonant-Card-label")).toBeNull();
+    expect(
+      screen.queryByTestId("consonant-Card-label-product-info")
+    ).toBeNull();
+  });
+
   test("should render a card title with a heading role and aria-level", () => {
     renderCard({ cardStyle });
 

--- a/react/src/js/components/Consonant/Cards/__tests__/Flex.spec.js
+++ b/react/src/js/components/Consonant/Cards/__tests__/Flex.spec.js
@@ -238,7 +238,6 @@ describe(`Consonant/Card/${cardStyle}`, () => {
     expect(
       productInfoElement.querySelector(".product-info-title")
     ).toBeNull();
-    expect(screen.queryByText("Acrobat")).toBeNull();
   });
 
   test("should not render the detail text when the product icon is shown", () => {


### PR DESCRIPTION
**Summary**
Add support for a new productIcon detail-text option alongside existing productName, showing only the product tag icon without the title
Card.jsx / FlexCard.jsx now match any detailsTextOption starting with product instead of the exact productName string
CardContent accepts a new productIconOnly prop to suppress rendering the product title span when only the icon should show

**Jira Ticket**
Resolves: [MWPW-204921](https://jira.corp.adobe.com/browse/MWPW-204921)

**Changes**
`react/src/js/components/Consonant/Cards/Card.jsx `— 
 broaden detailsTextOption check from `=== 'productName'` to `.startsWith('product')`
`react/src/js/components/Consonant/Cards/CardContent/CardContent.jsx` — 
 add `productIconOnly` prop; skip rendering product-info-title span when set
`react/src/js/components/Consonant/Cards/FlexCard.jsx` —
 compute `showProductIconOnly` from `detailsTextOption === 'productIcon'`, rename `showProductName` → `showProductInfo`, pass productIconOnly through to CardContent

**Test plan**
 [  ] Set detailsTextOption: 'productName' and confirm product icon + title still render as before
 [  ]  Set detailsTextOption: 'productIcon' and confirm only the icon renders (no title span)
 [  ]  Confirm non-product detailsTextOption values (e.g. date, hidden) are unaffected
 [  ]  Unit tests added/updated

**Notes**