### PR TITLE
feat(mwpw-000000): add the .pinata harness tenant contract

### DIFF
--- a/.pinata/.config.json
+++ b/.pinata/.config.json
@@ -1,0 +1,48 @@
+{
+    "source_app": "caas",
+    "name": "caas",
+    "app_name": "caas",
+    "github_repo": "adobecom/caas",
+    "default_branch": "main",
+    "branch_naming": "jira",
+    "branch_naming_prefixes": ["MWPW"],
+    "services": [
+        { "name": "harness", "env_var": "CAAS_PORT", "default": 3000 }
+    ],
+    "depends_on": [],
+    "pipeline": {
+        "event_trail": true,
+        "structured_prd": true,
+        "progress_tracking": {
+            "github": true,
+            "slack": true
+        }
+    },
+    "test_urls": {
+        "envs": {
+            "@caas_local": "http://localhost:3000",
+            "@bacom_live": "https://business.adobe.com/resources/main.html",
+            "@adobe_prod": "https://www.adobe.com"
+        },
+        "default_path": "/index.html"
+    },
+    "verify": {
+        "command": "NODE_OPTIONS=--openssl-legacy-provider npm run build",
+        "after": ["build", "fix", "patch"],
+        "cwd": ".",
+        "timeout_seconds": 600,
+        "max_attempts": 1,
+        "on_failure": {
+            "draft_pr": true,
+            "exit_nonzero": false
+        }
+    },
+    "mental_models": {
+        "domains": ["caas-consonant", "caas-quality"],
+        "path_overrides": [
+            { "pattern": "e2e-tests/", "domains": ["caas-quality"] },
+            { "pattern": ".github/qa/", "domains": ["caas-quality"] },
+            { "pattern": "less/", "domains": ["caas-consonant"] }
+        ]
+    }
+}

--- a/.pinata/README.md
+++ b/.pinata/README.md
@@ -1,0 +1,48 @@
+# .pinata/ — the CaaS tenant contract for the ACOM AI Harness
+
+This directory is how the harness (Fiesta) learns to work on CaaS without the
+platform holding any CaaS-specific knowledge. The harness reads it at a pinned
+commit per run; changing a file here changes how runs against this repo plan,
+verify, and open PRs — nothing else in the repo is affected.
+
+## Files
+
+| File | Role |
+|---|---|
+| `manifest.yaml` | Identity (org/product/repo) + which shared mental models the planner consults |
+| `gates.yaml` | The verification gates every candidate change must pass, with real repo commands |
+| `floor/gates.yaml` | Vendored snapshot of the acom org floor — the minimum no tenant may weaken |
+| `pr.yaml` | PR body template + branch naming for harness-authored changes |
+| `scripts/check-render.py` | Renderability gate: the built bundle must mount a card collection in headless chromium |
+| `scripts/check-contract.py` | CI linter: this contract stays well-formed and at least as strict as the floor |
+| `.config.json` | pinata-code app config (services, test URL registry, verify command) |
+
+## The gates, and where each came from
+
+Every gate mirrors something this repo already enforces or ships:
+
+- **lockfiles** — `package-lock.json` is protected; dependency bumps are their own ticket.
+- **lint** — diff-scoped check-only ESLint. `npm run lint` bakes in `--fix`, and the
+  base tree carries pre-existing violations, so repo-wide check-only fails on main.
+- **unit-tests** — `npx jest`; `jest.config.js` enforces global coverage thresholds,
+  so this is simultaneously the test gate and the coverage gate.
+- **build** — the production webpack build, with `NODE_OPTIONS=--openssl-legacy-provider`
+  exactly as the repo's own QA workflows run it on modern node.
+- **renderability** — deterministic port of `.github/qa/caas-render.mjs`: serve
+  `index.html` + built bundle + `mock-json/`, require the Consonant grid, ≥1 card,
+  and no uncaught page errors.
+- **adversary** — org-floor-mandated independent model review; the harness-side
+  counterpart of `.github/workflows/ai-code-review.yml`.
+
+Every command above was executed against a clean checkout before being declared.
+
+## Not here yet (deliberate)
+
+- **Visual gate** — needs either in-pod serving for judged screenshots or a branch
+  preview host; the renderability gate covers "it actually mounts" deterministically.
+- **PR title shaping** — caas CI lints titles (`type(mwpw-NNNNNN): message`); the
+  harness cannot yet emit that shape (see `pr.yaml` header).
+- **a11y audit scenarios** — `.github/qa/qa-prompts/` knowledge is captured in the
+  `caas-quality` mental model; automated axe checks are a candidate follow-up gate.
+
+Questions: `#javelin-friends` (CaaS) / the ACOM AI Harness team (contract).

--- a/.pinata/floor/gates.yaml
+++ b/.pinata/floor/gates.yaml
@@ -1,0 +1,32 @@
+# acom org floor (INV-3, R-8) — the verification minimum every acom product
+# must meet. A tenant's .pinata/gates.yaml may add gates or tighten these,
+# never weaken them: run_gates and the gate.run handler enforce this at run
+# time (packages/verification/gate_strictness.py), and each tenant repo lints
+# its contract against its vendored floor snapshot (.pinata/floor/gates.yaml)
+# in CI.
+#
+# This file is org POLICY and part of the TCB (see .pinata/gates.yaml
+# tcb-guard): the platform team changes it; the self-improvement loop may not.
+regeneration:
+    # Maximum total producer candidates; tenants inherit or tighten downward.
+    max_candidates: 5
+
+gates:
+    adversary:
+        template: adversary
+        name: Adversarial review — independent merge gate (INV-4)
+        description: >-
+            A change merges on an independent adversary's verdict (different model
+            class, no producer context), never the producer's self-assessment.
+            Binds every acom product; tenants may tighten but not drop it. Skips
+            honestly when no adversary model is reachable in dev.
+        blocking: true
+        # TODO(operator, temporary — 2026-07-06): loosened from `escalate_to_human`
+        # to `regenerate` so an adversary failure re-enters codegen for a bounded
+        # producer rebuild (regeneration.max_candidates) with the concerns as feedback,
+        # escalating to a human only at round exhaustion — instead of stopping on the
+        # first failure. This is an INV-6 TCB change made under explicit operator
+        # authority (the loop itself may not make it). It only RELAXES the floor
+        # (tenants may still tighten to escalate_to_human); revisit the round budget
+        # and re-tighten as the loop earns trust.
+        failure_route: regenerate

--- a/.pinata/gates.yaml
+++ b/.pinata/gates.yaml
@@ -1,0 +1,107 @@
+# CaaS verification gates. When this file is present the harness runs these in
+# place of its built-in set; commands run in the worktree.
+#
+# Mirrors what the repo's own merge path enforces (.github/workflows/
+# pull-request.yaml: lint, build, unit tests + coverage thresholds) plus a
+# deterministic port of the Feature QA Review agent's render probe
+# (.github/qa/caas-render.mjs). Every command below was run against a clean
+# checkout before being declared here.
+
+# Producer rebuild budget for gates that route to regenerate; the acom floor
+# caps it at 5 and tenants may only tighten it.
+regeneration:
+    max_candidates: 5
+
+# Command gates need the pinned devDeps. The repo's own .npmrc sets
+# legacy-peer-deps, so a plain ci works on modern node.
+provision: npm ci
+
+gates:
+    lockfiles:
+        template: protected_paths
+        name: Dependency lockfile
+        # An npm install during a code change rewrites this as a side effect.
+        # Dependency bumps are their own ticket.
+        paths:
+            - 'package-lock.json'
+        blocking: true
+        failure_route: escalate_to_human
+
+    lint:
+        template: command
+        name: ESLint (changed files)
+        # Diff-scoped on purpose: `npm run lint` bakes in --fix (it mutates the
+        # tree and hides fixable errors), and the base tree carries pre-existing
+        # violations outside the changed set — a repo-wide check-only run fails
+        # on main. Measured, not assumed.
+        cmd: npx eslint {js_files}
+        blocking: true
+        failure_route: repair_loop
+        repair:
+            cmd: npx eslint {js_files} --fix
+
+    unit-tests:
+        template: command
+        name: Jest unit suites + coverage thresholds
+        # jest.config.js sets collectCoverage: true with global thresholds
+        # (97.4% lines / 82% branches), so this single command is BOTH the test
+        # gate and the coverage gate: a candidate that adds untested code fails
+        # here until the producer ships tests with it. Full run measured at
+        # 73 suites / 918 tests in ~7s on a clean checkout.
+        cmd: npx jest
+        timeout_s: 600
+        blocking: true
+        failure_route: regenerate
+
+    build:
+        template: command
+        name: Webpack production build
+        # webpack 3 uses MD4 hashing, removed from OpenSSL 3: on node >= 17 the
+        # build dies with ERR_OSSL_EVP_UNSUPPORTED unless the legacy provider is
+        # enabled. This is the repo's own documented posture — its QA workflows
+        # build exactly this way on modern node (.github/workflows/
+        # qa-agent-review.yml); upstream CI avoids it by pinning node 16.13.1,
+        # which the harness image does not ship.
+        cmd: NODE_OPTIONS=--openssl-legacy-provider npm run build
+        timeout_s: 300
+        blocking: true
+        failure_route: regenerate
+
+    renderability:
+        template: command
+        name: Bundle mounts a card collection (headless chromium)
+        # Deterministic port of the Feature QA Review agent's render probe
+        # (.github/qa/caas-render.mjs): serve the repo's own local harness
+        # (index.html + dist/main.min.js + mock-json/) and require the Consonant
+        # grid to mount, >= 1 card to render, and no uncaught page errors. Unit
+        # tests exercise components in jsdom; webpack can still emit a bundle
+        # that throws on a real page, and nothing else on the merge path loads
+        # one. Chromium + playwright come from the harness image.
+        cmd: python3 .pinata/scripts/check-render.py
+        timeout_s: 300
+        blocking: true
+        # The probe cannot repair a bundle; the producer redoes the candidate.
+        failure_route: regenerate
+
+    # No format gate: the repo has no prettier config — formatting is ESLint's
+    # job here, and the lint gate's repair already runs --fix.
+    #
+    # No dist-sync gate: dist/* is gitignored except two vendored React UMDs
+    # (.gitignore:123) — build outputs are not committed, so there is nothing
+    # to drift.
+
+    # Last on purpose: the adversary reviews the code together with every
+    # deterministic gate result, not blind of them.
+    adversary:
+        template: adversary
+        name: Adversarial review — independent merge gate (INV-4)
+        description: >-
+            Independent-model review of the diff before merge, required by the
+            acom org floor. Plays the role caas's own ai-code-review.yml plays
+            upstream (stateful LLM diff review): correctness, security, data
+            loss — style and nits belong to the lint gate. Skips honestly when
+            no adversary model is reachable.
+        blocking: true
+        # Floor 2026-07-06 posture: bounded producer rebuild with the concerns
+        # as feedback, human review only at round exhaustion.
+        failure_route: regenerate

--- a/.pinata/manifest.yaml
+++ b/.pinata/manifest.yaml
@@ -1,0 +1,17 @@
+# Fiesta tenant contract — CaaS (Content as a Service, aka Chimera) identity.
+#
+# The harness reads this at the pinned commit and holds no CaaS-specific
+# knowledge of its own. Identity ladder: adobe (company) > acom (org) >
+# caas (product) > … . Unknown keys are rejected, so a typo fails loudly.
+org: acom
+product: caas
+repo: adobecom/caas
+owners_from: CODEOWNERS
+
+# Which shared mental models the planner consults for CaaS work. Selection is
+# tenant-owned; content resolves from the shared registry
+# (Adobe-acom/pinata-tool-shelf/mental-models/) at run time.
+mental_models:
+    use:
+        - caas-consonant
+        - caas-quality

--- a/.pinata/pr.yaml
+++ b/.pinata/pr.yaml
@@ -1,0 +1,32 @@
+# PR body and branch naming for harness-authored CaaS changes.
+#
+# KNOWN GAP (engine follow-up, not fixable from this file): caas CI lints PR
+# TITLES via commitlint — `type(mwpw-NNNNNN): message` (commitlint.config.js,
+# check-pr-title in pull-request.yaml). The harness currently titles PRs
+# "[pinata-code] <issue title>", which that check rejects. pr.yaml has no title
+# field today; until the engine grows one, a harness PR needs its title edited
+# once (e.g. `fix(mwpw-184448): …`) to go green.
+issue_key_pattern: 'MWPW-\d+'
+# Ticket-first branches, matching the team convention (AGENTS.md: ticket
+# number in every change; branches off main).
+branch_pattern: ['{issue_key}', '{title_slug}']
+page: /index.html
+fallbacks:
+    issue_key: 'Resolves: <!-- link the MWPW Jira ticket, e.g. [MWPW-0000](…) -->'
+    test_urls: |-
+        - Local harness: `npm start` → http://localhost:3000/index.html (mock data)
+        - <!-- no verified visual evidence this run — see the run dashboard -->
+template: |
+    {summary_bullets}
+
+    Resolves: [{issue_key}](https://jira.corp.adobe.com/browse/{issue_key})
+
+    **Verification** (what the harness ran green before opening this PR):
+    - ESLint on the changed files, check-only
+    - `npx jest` — full unit suites with the repo's coverage thresholds
+    - `NODE_OPTIONS=--openssl-legacy-provider npm run build`
+    - Renderability: the built bundle mounted a Consonant card collection on
+      the local harness (index.html + mock-json) in headless chromium
+
+    **Test URLs**:
+    {test_urls}

--- a/.pinata/scripts/check-contract.py
+++ b/.pinata/scripts/check-contract.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Reference-integrity check for the .pinata/ tenant contract (R-14).
+
+Validates that the contract files parse with their required shapes, and that
+every mental-model id declared in manifest.yaml resolves to a directory in the
+shared registry (Adobe-acom/pinata-tool-shelf). Contract-shape problems always
+fail; the registry check degrades to a warning when the registry cannot be
+cloned (e.g. no token in a fork's CI).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+FIESTA = Path(__file__).resolve().parents[1]
+REGISTRY_URL = "https://github.com/Adobe-acom/pinata-tool-shelf.git"
+errors: list[str] = []
+
+
+def _load(name: str, required: bool = False) -> dict | None:
+    path = FIESTA / name
+    if not path.exists():
+        if required:
+            errors.append(f"{name}: missing (required)")
+        return None
+    try:
+        data = yaml.safe_load(path.read_text())
+    except yaml.YAMLError as exc:
+        errors.append(f"{name}: malformed YAML: {exc}")
+        return None
+    if not isinstance(data, dict):
+        errors.append(f"{name}: must be a mapping")
+        return None
+    return data
+
+
+manifest = _load("manifest.yaml", required=True) or {}
+for field in ("org", "product", "repo"):
+    if not manifest.get(field):
+        errors.append(f"manifest.yaml: missing required field '{field}'")
+
+gates = _load("gates.yaml")
+if gates is not None:
+    for gate_id, defn in (gates.get("gates") or {}).items():
+        if not isinstance(defn, dict) or not defn.get("template"):
+            errors.append(f"gates.yaml: gate '{gate_id}' needs a template")
+
+
+def _regeneration_max(document: dict | None, label: str) -> int | None:
+    if document is None or "regeneration" not in document:
+        return None
+    policy = document["regeneration"]
+    if not isinstance(policy, dict):
+        errors.append(f"{label}: regeneration must be a mapping")
+        return None
+    unknown = sorted(set(policy) - {"max_candidates"})
+    if unknown:
+        errors.append(f"{label}: regeneration has unknown fields {unknown}")
+    value = policy.get("max_candidates")
+    if type(value) is not int or value < 1:
+        errors.append(f"{label}: regeneration.max_candidates must be a positive integer")
+        return None
+    return value
+
+
+def _route(defn: dict) -> str:
+    # Mirrors the harness default: an unset failure_route is the strictest.
+    return defn.get("failure_route") or "escalate_to_human"
+
+
+def _autonomous_route(defn: dict) -> bool:
+    return _route(defn) in {"repair_loop", "regenerate"}
+
+
+# INV-3 monotonic strictness (R-8): tenant gates may only tighten the org
+# floor, never weaken it. The floor snapshot is vendored at
+# .pinata/floor/gates.yaml (source of truth: fiesta config/floors/<org>/ —
+# the harness enforces THAT one at run time; this lint catches a weakening
+# PR in CI before it ever reaches a run).
+floor = _load("floor/gates.yaml")
+tenant_regeneration_max = _regeneration_max(gates, "gates.yaml")
+floor_regeneration_max = _regeneration_max(floor, "floor/gates.yaml")
+if floor is None:
+    print("WARN: no .pinata/floor/gates.yaml snapshot — INV-3 strictness lint skipped")
+elif gates is not None:
+    if (
+        floor_regeneration_max is not None
+        and tenant_regeneration_max is not None
+        and tenant_regeneration_max > floor_regeneration_max
+    ):
+        errors.append(
+            "gates.yaml: regeneration.max_candidates "
+            f"{tenant_regeneration_max} exceeds the org floor ceiling "
+            f"{floor_regeneration_max} (INV-3)"
+        )
+    tenant_gates = gates.get("gates") or {}
+    for name, fdef in (floor.get("gates") or {}).items():
+        tdef = tenant_gates.get(name)
+        if not isinstance(tdef, dict):
+            errors.append(f"gates.yaml: gate '{name}' is required by the org floor but missing (INV-3)")
+            continue
+        if tdef.get("template") != fdef.get("template"):
+            errors.append(
+                f"gates.yaml: gate '{name}' changes the org floor template "
+                f"'{fdef.get('template')}' to '{tdef.get('template')}' (INV-3)"
+            )
+        if fdef.get("blocking", True) and not tdef.get("blocking", True):
+            errors.append(f"gates.yaml: gate '{name}' is blocking in the org floor but advisory here (INV-3)")
+        if fdef.get("threshold") is not None and (
+            tdef.get("threshold") is None or tdef["threshold"] < fdef["threshold"]
+        ):
+            errors.append(
+                f"gates.yaml: gate '{name}' drops or lowers the org floor threshold {fdef['threshold']} (INV-3)"
+            )
+        if not _autonomous_route(fdef) and _autonomous_route(tdef):
+            errors.append(
+                f"gates.yaml: gate '{name}' downgrades the org floor failure_route "
+                f"to autonomous {_route(tdef)} (INV-3)"
+            )
+        if fdef.get("require_human", True) and not tdef.get("require_human", True):
+            errors.append(f"gates.yaml: gate '{name}' drops require_human, which the org floor mandates (INV-3)")
+
+preview = _load("preview.yaml")
+if preview is not None:
+    if not preview.get("pin_pattern"):
+        errors.append("preview.yaml: missing pin_pattern")
+    for i, surface in enumerate(preview.get("surfaces") or []):
+        label = f"preview.yaml: surfaces[{i}]"
+        if not isinstance(surface, dict) or not surface.get("id"):
+            errors.append(f"{label}: needs an id")
+            continue
+        if bool(surface.get("page")) == bool(surface.get("url")):
+            errors.append(f"preview.yaml: surface '{surface['id']}' needs exactly one of page/url")
+        if not surface.get("description"):
+            errors.append(
+                f"preview.yaml: surface '{surface['id']}' needs a description "
+                "(the selector's only page signal)"
+            )
+
+pr = _load("pr.yaml")
+if pr is not None and not pr.get("template"):
+    errors.append("pr.yaml: missing template")
+
+for wf in sorted((FIESTA / "workflows").glob("*.yaml")) if (FIESTA / "workflows").is_dir() else []:
+    try:
+        data = yaml.safe_load(wf.read_text()) or {}
+        if not data.get("workflow_id"):
+            errors.append(f"workflows/{wf.name}: missing workflow_id")
+    except yaml.YAMLError as exc:
+        errors.append(f"workflows/{wf.name}: malformed YAML: {exc}")
+
+ids = [str(i) for i in ((manifest.get("mental_models") or {}).get("use") or [])]
+if ids:
+    with tempfile.TemporaryDirectory() as tmp:
+        clone = subprocess.run(
+            ["git", "clone", "--depth", "1", REGISTRY_URL, tmp],
+            capture_output=True, text=True, timeout=120,
+        )
+        if clone.returncode != 0:
+            print(f"WARN: could not clone the mental-model registry — id check skipped:\n{clone.stderr[-300:]}")
+        else:
+            available = {p.name for p in (Path(tmp) / "mental-models").iterdir() if p.is_dir()}
+            dangling = [i for i in ids if i not in available]
+            if dangling:
+                errors.append(
+                    f"manifest.yaml: mental_models.use ids not in the registry: {dangling} "
+                    f"(available: {sorted(available)})"
+                )
+
+if errors:
+    print("fiesta contract check FAILED:")
+    for e in errors:
+        print(f"  - {e}")
+    sys.exit(1)
+print("fiesta contract check passed")

--- a/.pinata/scripts/check-render.py
+++ b/.pinata/scripts/check-render.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Renderability smoke: the built bundle must actually mount a card collection.
+
+Port of .github/qa/caas-render.mjs (the deterministic half of the Feature QA
+Review agent) into a worktree gate. Unit tests exercise components in jsdom;
+webpack can still produce a bundle that throws on a real page, and nothing
+else on the merge path loads one. This serves the repo's own local harness --
+index.html + dist/main.min.js + mock-json/ -- in headless chromium and fails
+unless the Consonant grid mounts, cards render, and the console stays clean.
+
+Requirements come from the harness image (playwright + chromium are baked in);
+run locally with any python that has playwright installed. Builds the bundle
+first if dist/main.min.js is missing, using the repo's own documented flag
+(NODE_OPTIONS=--openssl-legacy-provider -- webpack 3 vs OpenSSL 3, see
+.github/workflows/qa-agent-review.yml).
+"""
+
+from __future__ import annotations
+
+import http.server
+import os
+import socket
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MIN_CARDS = 1
+# consonant-Card is the per-card class; the grid/container proves the
+# collection shell mounted even when a config yields zero cards.
+GRID_SELECTOR = ".consonant-CardsGrid, [class*='consonant-Container']"
+CARD_SELECTOR = ".consonant-Card"
+
+
+def ensure_bundle() -> None:
+    if (ROOT / "dist" / "main.min.js").is_file():
+        return
+    print("dist/main.min.js missing; building (openssl-legacy-provider)...")
+    env = {**os.environ, "NODE_OPTIONS": "--openssl-legacy-provider"}
+    subprocess.run(["npm", "run", "build"], cwd=ROOT, env=env, check=True, timeout=600)
+
+
+def serve() -> tuple[http.server.ThreadingHTTPServer, int]:
+    handler = lambda *a, **kw: http.server.SimpleHTTPRequestHandler(  # noqa: E731
+        *a, directory=str(ROOT), **kw
+    )
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+    httpd = http.server.ThreadingHTTPServer(("127.0.0.1", port), handler)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    return httpd, port
+
+
+def main() -> int:
+    ensure_bundle()
+    httpd, port = serve()
+    # MUST be the literal hostname "localhost": index.html's endpoint switch
+    # (line ~93) only serves mock-json when location.hostname == "localhost";
+    # any other host sends the page to the live chimera API, which a sandboxed
+    # worktree cannot (and must not) depend on.
+    url = f"http://localhost:{port}/index.html"
+    from playwright.sync_api import sync_playwright
+
+    console_errors: list[str] = []
+    page_errors: list[str] = []
+    try:
+        with sync_playwright() as pw:
+            browser = pw.chromium.launch(headless=True)
+            page = browser.new_page()
+            page.on(
+                "console",
+                lambda m: console_errors.append(m.text[:200]) if m.type == "error" else None,
+            )
+            page.on("pageerror", lambda e: page_errors.append(str(e)[:200]))
+            page.goto(url, wait_until="load", timeout=30_000)
+            try:
+                page.wait_for_selector(GRID_SELECTOR, timeout=20_000)
+            except Exception:
+                pass  # judged below with evidence, not by the raw timeout
+            grid = page.query_selector(GRID_SELECTOR) is not None
+            cards = len(page.query_selector_all(CARD_SELECTOR))
+            browser.close()
+    finally:
+        httpd.shutdown()
+
+    print(f"grid={grid} cards={cards} console_errors={len(console_errors)} page_errors={len(page_errors)}")
+    for e in (console_errors + page_errors)[:6]:
+        print(f"  ! {e}")
+    failures = []
+    if not grid:
+        failures.append("the Consonant collection container never mounted")
+    if cards < MIN_CARDS:
+        failures.append(f"expected >= {MIN_CARDS} rendered .consonant-Card, saw {cards}")
+    if page_errors:
+        failures.append("uncaught page errors during render")
+    # Resource-load 404s are baseline noise on the local harness (index.html
+    # references www.caas.com/libs/utils/lana.js, absent when served locally)
+    # and never indicate a bundle regression; a thrown error in the bundle
+    # surfaces as a pageerror or a non-resource console error instead.
+    real_console = [e for e in console_errors if not e.startswith("Failed to load resource")]
+    if real_console:
+        failures.append("console errors during render")
+    if failures:
+        print("RENDERABILITY FAIL: " + "; ".join(failures))
+        return 1
+    print("RENDERABILITY PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why we're merging this — in plain terms

This teaches the ACOM AI Harness how to work on CaaS. The harness is the system that takes a ticket, writes the change, verifies it, and opens a PR — it already does this for M@S, and this folder is how a repo tells it the house rules.

Everything lives in one new directory, `.pinata/`. Nothing outside it changes, no workflow triggers on it, and it has no effect until a harness run targets this repo.

The checks it declares are the ones this repo already lives by — ESLint, the full jest suite with its coverage bars, the production webpack build — plus one genuinely new safety net: a **renderability check** that loads the built bundle on the repo's own local harness page in a headless browser and refuses any change where the card collection stops mounting. Unit tests run in a simulated DOM, so today a bundle that throws on a real page can pass everything; this closes that gap, deterministically.

An independent-model code review (the same role `ai-code-review.yml` plays here) is mandatory before any harness change merges — that's org policy, vendored under `.pinata/floor/`.

⚠️ **Before merge**: the ticket in the PR title is a placeholder (`mwpw-000000`) — swap in the real onboarding ticket. Shape already passes `check-pr-title` and the husky hook.

<details><summary>Technical detail</summary>

### Gates (in run order)

| Gate | Command | Why this shape |
|---|---|---|
| lockfiles | protected path `package-lock.json` | dependency bumps are their own ticket |
| lint | `npx eslint {changed js}` (+ `--fix` as declared repair) | `npm run lint` bakes in `--fix` and check-only over its own scope fails on main today (1 pre-existing error, measured) — so diff-scoped |
| unit-tests | `npx jest` | `jest.config.js` enforces global coverage thresholds unconditionally (97.4% lines / 82% branches) — this is simultaneously the test gate and a ship-tests-with-the-change gate. 73 suites / 918 tests / ~7s, verified green |
| build | `NODE_OPTIONS=--openssl-legacy-provider npm run build` | webpack 3's MD4 vs OpenSSL 3 on node ≥17; exactly how this repo's own QA workflows build on modern node (`qa-agent-review.yml`) — verified |
| renderability | `python3 .pinata/scripts/check-render.py` | deterministic port of `.github/qa/caas-render.mjs`: serve `index.html` + `dist/main.min.js` + `mock-json/`, require `.consonant-CardsGrid`, ≥1 `.consonant-Card`, no uncaught page errors |
| adversary | independent-model diff review | acom org floor (INV-4); harness-side counterpart of `ai-code-review.yml` |

No dist-sync gate (`dist/*` is gitignored except the vendored React UMDs) and no format gate (no prettier config — formatting is ESLint's job).

### The renderability probe, verified both directions

```
clean tree          → grid=True  cards=7 → PASS
sabotaged main.min.js → grid=False cards=0, pageerror → FAIL
```

Two measured harness facts are encoded in it: `index.html`'s mock-data switch requires the literal hostname `localhost` (any other host — including `127.0.0.1` — silently points at production chimera-api), and the local page has one baseline `lana.js` resource-404 that is noise, not signal.

### Validation

The whole contract loads through the harness's own loaders (manifest, gate dispatch, org-floor enforcement for `acom`, PR template). `scripts/check-contract.py` (shared tenant linter, no caas-specifics) passes — and fails with the exact INV-3 error if the adversary gate is removed, which was checked by removing it.

### Pairs with

[Adobe-acom/pinata-tool-shelf#11](https://github.com/Adobe-acom/pinata-tool-shelf/pull/11) adds the `caas-consonant` and `caas-quality` mental models this manifest references — **merge that first** (this contract's linter cross-checks the ids). Until it lands the harness simply finds no declared models and falls back, so it is a soft ordering, not a hard dependency.

### Known gaps (tracked harness-side, not fixable from this folder)

- Harness PR titles don't yet match this repo's commitlint shape — engine follow-up (`title_pattern` in pr.yaml).
- The harness GitHub App is not installed on adobecom/caas, so harness runs cannot push here yet.
- Visual (screenshot-judged) gate deferred until a preview mechanism exists for caas; renderability covers mounting deterministically.
</details>
